### PR TITLE
Add drawer editing to vintage template

### DIFF
--- a/components/editor/templates/vintage/VintageEditableMenuItem.tsx
+++ b/components/editor/templates/vintage/VintageEditableMenuItem.tsx
@@ -1,99 +1,122 @@
-"use client"
+"use client";
 
-import React, { useRef, useState, useEffect } from 'react'
-import { useDrag, useDrop } from 'react-dnd'
-import { GripVertical, Edit, Save, X, Trash2 } from 'lucide-react'
-import { useMenuEditor, type MenuItem, type RowStyleSettings } from '@/contexts/menu-editor-context'
-import { resolveFontFamily } from '@/lib/font-config'
-import { Input } from '@/components/ui/input'
-import { Textarea } from '@/components/ui/textarea'
-import { Button } from '@/components/ui/button'
+import React, { useRef, useState, useEffect } from "react";
+import { useDrag, useDrop } from "react-dnd";
+import { GripVertical, Edit, Save, X, Trash2 } from "lucide-react";
+import {
+  useMenuEditor,
+  type MenuItem,
+  type RowStyleSettings,
+} from "@/contexts/menu-editor-context";
+import { resolveFontFamily } from "@/lib/font-config";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerFooter,
+} from "@/components/ui/drawer";
 
 const ItemTypes = {
-  MENU_ITEM: 'menu_item',
-}
+  MENU_ITEM: "menu_item",
+};
 
 interface VintageEditableMenuItemProps {
-  item: MenuItem
-  index: number
-  categoryId: string
-  moveItem: (dragIndex: number, hoverIndex: number) => void
-  currencySymbol: string
-  appliedRowStyles: RowStyleSettings
+  item: MenuItem;
+  index: number;
+  categoryId: string;
+  moveItem: (dragIndex: number, hoverIndex: number) => void;
+  currencySymbol: string;
+  appliedRowStyles: RowStyleSettings;
 }
 
-const VintageEditableMenuItem: React.FC<VintageEditableMenuItemProps> = ({ item, categoryId, index, moveItem, currencySymbol, appliedRowStyles }) => {
-  const { 
+const VintageEditableMenuItem: React.FC<VintageEditableMenuItemProps> = ({
+  item,
+  categoryId,
+  index,
+  moveItem,
+  currencySymbol,
+  appliedRowStyles,
+}) => {
+  const {
     handleUpdateItem,
-    appliedFontSettings, 
-    handleSaveNewItem, 
+    appliedFontSettings,
+    handleSaveNewItem,
     handleDeleteItem,
     showConfirmation,
     currentPalette,
     currentLanguage,
     isPreviewMode,
-  } = useMenuEditor()
+  } = useMenuEditor();
 
-  const ref = useRef<HTMLDivElement>(null)
-  const [isEditing, setIsEditing] = useState(item.isTemporary || false)
-  const [editedItem, setEditedItem] = useState(item)
+  const ref = useRef<HTMLDivElement>(null);
+  const [isEditing, setIsEditing] = useState(item.isTemporary || false);
+  const [editedItem, setEditedItem] = useState(item);
 
   useEffect(() => {
     if (item.isTemporary) {
-      setIsEditing(true)
+      setIsEditing(true);
     }
-  }, [item.isTemporary])
-  
+  }, [item.isTemporary]);
+
   const onSave = () => {
     if (item.isTemporary) {
-      handleSaveNewItem({ ...editedItem, category_id: categoryId })
+      handleSaveNewItem({ ...editedItem, category_id: categoryId });
     } else {
-      handleUpdateItem(editedItem)
+      handleUpdateItem(editedItem);
     }
-    setIsEditing(false)
-  }
+    setIsEditing(false);
+  };
 
   const onCancel = () => {
     if (item.isTemporary) {
-      handleDeleteItem(item.id)
+      handleDeleteItem(item.id);
     } else {
-      setEditedItem(item)
-      setIsEditing(false)
+      setEditedItem(item);
+      setIsEditing(false);
     }
-  }
+  };
 
   const onDeleteConfirm = () => {
     showConfirmation(
-        `Delete '${item.name}'?`,
-        "Are you sure you want to delete this item? This action cannot be undone.",
-        () => handleDeleteItem(item.id),
-        'danger'
-    )
-  }
+      `Delete '${item.name}'?`,
+      "Are you sure you want to delete this item? This action cannot be undone.",
+      () => handleDeleteItem(item.id),
+      "danger",
+    );
+  };
 
-  const [{ handlerId }, drop] = useDrop<{ id: string; index: number }, void, { handlerId: string | symbol | null }>({
+  const [{ handlerId }, drop] = useDrop<
+    { id: string; index: number },
+    void,
+    { handlerId: string | symbol | null }
+  >({
     accept: ItemTypes.MENU_ITEM,
     collect: (monitor) => ({
       handlerId: monitor.getHandlerId(),
     }),
     hover(draggedItem: { id: string; index: number }, monitor) {
-      if (!ref.current) return
-      const dragIndex = draggedItem.index
-      const hoverIndex = index
-      if (dragIndex === hoverIndex) return
+      if (!ref.current) return;
+      const dragIndex = draggedItem.index;
+      const hoverIndex = index;
+      if (dragIndex === hoverIndex) return;
 
-      const hoverBoundingRect = ref.current?.getBoundingClientRect()
-      const hoverMiddleY = (hoverBoundingRect.bottom - hoverBoundingRect.top) / 2
-      const clientOffset = monitor.getClientOffset()
-      const hoverClientY = clientOffset!.y - hoverBoundingRect.top
-      
-      if (dragIndex < hoverIndex && hoverClientY < hoverMiddleY) return
-      if (dragIndex > hoverIndex && hoverClientY > hoverMiddleY) return
-      
-      moveItem(dragIndex, hoverIndex)
-      draggedItem.index = hoverIndex
+      const hoverBoundingRect = ref.current?.getBoundingClientRect();
+      const hoverMiddleY =
+        (hoverBoundingRect.bottom - hoverBoundingRect.top) / 2;
+      const clientOffset = monitor.getClientOffset();
+      const hoverClientY = clientOffset!.y - hoverBoundingRect.top;
+
+      if (dragIndex < hoverIndex && hoverClientY < hoverMiddleY) return;
+      if (dragIndex > hoverIndex && hoverClientY > hoverMiddleY) return;
+
+      moveItem(dragIndex, hoverIndex);
+      draggedItem.index = hoverIndex;
     },
-  })
+  });
 
   const [{ isDragging }, drag] = useDrag({
     type: ItemTypes.MENU_ITEM,
@@ -101,86 +124,102 @@ const VintageEditableMenuItem: React.FC<VintageEditableMenuItemProps> = ({ item,
     collect: (monitor) => ({
       isDragging: monitor.isDragging(),
     }),
-  })
+  });
 
-  drag(drop(ref))
+  drag(drop(ref));
 
-  const isArabic = currentLanguage === 'ar';
-  const activeFontSettings = isArabic ? appliedFontSettings.arabic : appliedFontSettings.english;
+  const isArabic = currentLanguage === "ar";
+  const activeFontSettings = isArabic
+    ? appliedFontSettings.arabic
+    : appliedFontSettings.english;
 
   const itemContainerStyle: React.CSSProperties = {
     opacity: isDragging ? 0.5 : 1,
   };
 
   if (appliedRowStyles) {
-    if (appliedRowStyles.backgroundType === 'solid') {
+    if (appliedRowStyles.backgroundType === "solid") {
       itemContainerStyle.backgroundColor = appliedRowStyles.backgroundColor;
     }
     if (appliedRowStyles.borderBottom.enabled) {
-      itemContainerStyle.borderStyle = 'solid';
+      itemContainerStyle.borderStyle = "solid";
       itemContainerStyle.borderWidth = `${appliedRowStyles.borderBottom.width}px`;
       itemContainerStyle.borderColor = appliedRowStyles.borderBottom.color;
       itemContainerStyle.borderRadius = `${appliedRowStyles.borderRadius}px`;
-      itemContainerStyle.padding = '1rem';
+      itemContainerStyle.padding = "1rem";
     }
   }
 
   // Style objects for dynamic fonts
   const nameStyle = {
     fontFamily: resolveFontFamily(activeFontSettings.font),
-    fontWeight: activeFontSettings.weight || 'bold',
+    fontWeight: activeFontSettings.weight || "bold",
     color: appliedRowStyles?.itemColor || currentPalette.primary,
-    textAlign: (isArabic ? 'right' : 'left') as 'right' | 'left',
+    textAlign: (isArabic ? "right" : "left") as "right" | "left",
   };
 
   const descriptionStyle = {
     fontFamily: resolveFontFamily(activeFontSettings.font),
     fontWeight: 400,
     color: appliedRowStyles?.descriptionColor || currentPalette.secondary,
-    textAlign: (isArabic ? 'right' : 'left') as 'right' | 'left',
+    textAlign: (isArabic ? "right" : "left") as "right" | "left",
   };
 
   const priceStyle = {
     fontFamily: resolveFontFamily(activeFontSettings.font),
-    fontWeight: activeFontSettings.weight || 'bold',
+    fontWeight: activeFontSettings.weight || "bold",
     color: appliedRowStyles?.priceColor || currentPalette.primary,
   };
 
   if (isEditing) {
     return (
-      <div ref={ref} className="p-3 my-2 border border-blue-400 rounded-md bg-white shadow-lg" style={itemContainerStyle} dir={isArabic ? 'rtl' : 'ltr'}>
-        <Input
-          value={editedItem.name}
-          onChange={(e) => setEditedItem(prev => ({ ...prev, name: e.target.value }))}
-          placeholder="Item Name"
-          className="text-base font-bold border-0 p-0"
-          style={nameStyle}
-        />
-        <Textarea
-          value={editedItem.description || ''}
-          onChange={(e) => setEditedItem(prev => ({ ...prev, description: e.target.value }))}
-          placeholder="Item description"
-          className="text-sm mt-1 border-0 p-0 h-auto"
-          style={descriptionStyle}
-        />
-        <div className={`flex justify-between items-center mt-2`}>
-          <div className={`flex items-center ${isArabic ? 'flex-row-reverse' : ''}`}>
-            <span className={isArabic ? 'ml-1' : 'mr-1'} style={priceStyle}>{currencySymbol}</span>
+      <Drawer open={isEditing} onOpenChange={setIsEditing}>
+        <DrawerContent className="p-6 space-y-4">
+          <DrawerHeader>
+            <DrawerTitle>{isArabic ? "تعديل عنصر" : "Edit Item"}</DrawerTitle>
+          </DrawerHeader>
+          <div className="space-y-3" dir={isArabic ? "rtl" : "ltr"}>
             <Input
-              value={editedItem.price ?? ''}
-              onChange={(e) => setEditedItem(prev => ({ ...prev, price: parseFloat(e.target.value) || 0 }))}
-              placeholder="Price"
-              type="number"
-              className="text-base font-bold w-20 border-0 p-0"
-              style={priceStyle}
+              value={editedItem.name}
+              onChange={(e) =>
+                setEditedItem((prev) => ({ ...prev, name: e.target.value }))
+              }
+              placeholder={isArabic ? "اسم العنصر" : "Item Name"}
             />
+            <Textarea
+              value={editedItem.description || ""}
+              onChange={(e) =>
+                setEditedItem((prev) => ({
+                  ...prev,
+                  description: e.target.value,
+                }))
+              }
+              placeholder={isArabic ? "وصف العنصر" : "Item description"}
+            />
+            <div className="flex items-center gap-2">
+              <span>{currencySymbol}</span>
+              <Input
+                value={editedItem.price ?? ""}
+                onChange={(e) =>
+                  setEditedItem((prev) => ({
+                    ...prev,
+                    price: parseFloat(e.target.value) || 0,
+                  }))
+                }
+                placeholder={isArabic ? "السعر" : "Price"}
+                type="number"
+                className="w-24"
+              />
+            </div>
           </div>
-          <div className="flex items-center">
-            <Button onClick={onSave} size="sm" variant="ghost"><Save className="h-4 w-4 text-green-600" /></Button>
-            <Button onClick={onCancel} size="sm" variant="ghost"><X className="h-4 w-4 text-red-600" /></Button>
-          </div>
-        </div>
-      </div>
+          <DrawerFooter className="flex justify-end gap-2">
+            <Button onClick={onCancel} variant="outline">
+              {isArabic ? "إلغاء" : "Cancel"}
+            </Button>
+            <Button onClick={onSave}>{isArabic ? "حفظ" : "Save"}</Button>
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
     );
   }
 
@@ -191,29 +230,54 @@ const VintageEditableMenuItem: React.FC<VintageEditableMenuItemProps> = ({ item,
       style={itemContainerStyle}
       className={`py-2 flex items-center justify-between w-full`}
     >
-        {!isPreviewMode && (
-          <div className={`cursor-move ${isArabic ? 'pl-2' : 'pr-2'}`}>
-              <GripVertical className="text-gray-400 h-4 w-4" />
-          </div>
-        )}
-      <div className={`flex items-center ${isArabic ? 'flex-row-reverse' : ''}`}>
+      {!isPreviewMode && (
+        <div className={`cursor-move ${isArabic ? "pl-2" : "pr-2"}`}>
+          <GripVertical className="text-gray-400 h-4 w-4" />
+        </div>
+      )}
+      <div
+        className={`flex items-center ${isArabic ? "flex-row-reverse" : ""}`}
+      >
         <div>
-            <h4 className="text-base font-bold" style={nameStyle}>{item.name}</h4>
-            {item.description && <p className="text-sm mt-1" style={descriptionStyle}>{item.description}</p>}
+          <h4 className="text-base font-bold" style={nameStyle}>
+            {item.name}
+          </h4>
+          {item.description && (
+            <p className="text-sm mt-1" style={descriptionStyle}>
+              {item.description}
+            </p>
+          )}
         </div>
       </div>
 
       <div className="flex items-center flex-shrink-0">
-        <p className="text-base font-bold" style={priceStyle}>{currencySymbol}{item.price}</p>
+        <p className="text-base font-bold" style={priceStyle}>
+          {currencySymbol}
+          {item.price}
+        </p>
         {!isPreviewMode && (
-          <div className={`flex items-center ${isArabic ? 'mr-2' : 'ml-2'}`}>
-            <Button onClick={() => setIsEditing(true)} variant="ghost" size="icon" className="h-8 w-8"><Edit className="w-4 h-4" /></Button>
-            <Button onClick={onDeleteConfirm} variant="ghost" size="icon" className="h-8 w-8"><Trash2 className="w-4 h-4 text-red-500" /></Button>
+          <div className={`flex items-center ${isArabic ? "mr-2" : "ml-2"}`}>
+            <Button
+              onClick={() => setIsEditing(true)}
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+            >
+              <Edit className="w-4 h-4" />
+            </Button>
+            <Button
+              onClick={onDeleteConfirm}
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+            >
+              <Trash2 className="w-4 h-4 text-red-500" />
+            </Button>
           </div>
         )}
       </div>
     </div>
-  )
-}
+  );
+};
 
-export default VintageEditableMenuItem 
+export default VintageEditableMenuItem;

--- a/components/editor/templates/vintage/VintageMenuSection.tsx
+++ b/components/editor/templates/vintage/VintageMenuSection.tsx
@@ -1,60 +1,75 @@
-"use client"
+"use client";
 
-import React, { useState, useEffect } from 'react'
-import { useMenuEditor, type MenuCategory, type RowStyleSettings } from '@/contexts/menu-editor-context'
-import VintageEditableMenuItem from './VintageEditableMenuItem'
-import { Button } from '@/components/ui/button'
-import { Plus, Edit, Save, X, Trash2 } from 'lucide-react'
-import { Input } from '@/components/ui/input'
-import { resolveFontFamily } from '@/lib/font-config'
+import React, { useState, useEffect } from "react";
+import {
+  useMenuEditor,
+  type MenuCategory,
+  type RowStyleSettings,
+} from "@/contexts/menu-editor-context";
+import VintageEditableMenuItem from "./VintageEditableMenuItem";
+import { Button } from "@/components/ui/button";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerFooter,
+} from "@/components/ui/drawer";
+import { Plus, Edit, Save, X, Trash2 } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { resolveFontFamily } from "@/lib/font-config";
 
 interface VintageMenuSectionProps {
-  category: MenuCategory
-  currencySymbol: string
-  appliedRowStyles: RowStyleSettings
+  category: MenuCategory;
+  currencySymbol: string;
+  appliedRowStyles: RowStyleSettings;
 }
 
-const VintageMenuSection: React.FC<VintageMenuSectionProps> = ({ category, currencySymbol, appliedRowStyles }) => {
-  const { 
-    handleAddItem, 
-    moveItem, 
-    handleUpdateCategory, 
+const VintageMenuSection: React.FC<VintageMenuSectionProps> = ({
+  category,
+  currencySymbol,
+  appliedRowStyles,
+}) => {
+  const {
+    handleAddItem,
+    moveItem,
+    handleUpdateCategory,
     handleDeleteCategory,
     handleSaveNewCategory,
     appliedFontSettings,
     currentPalette,
     currentLanguage,
     isPreviewMode,
-  } = useMenuEditor()
+  } = useMenuEditor();
 
-  const [isEditing, setIsEditing] = useState(category.isTemporary || false)
-  const [editedName, setEditedName] = useState(category.name)
+  const [isEditing, setIsEditing] = useState(category.isTemporary || false);
+  const [editedName, setEditedName] = useState(category.name);
 
   useEffect(() => {
     if (category.isTemporary) {
-      setIsEditing(true)
+      setIsEditing(true);
     }
-  }, [category.isTemporary])
+  }, [category.isTemporary]);
 
   const onSave = () => {
     if (category.isTemporary) {
-      handleSaveNewCategory({ ...category, name: editedName })
+      handleSaveNewCategory({ ...category, name: editedName });
     } else {
-      handleUpdateCategory(category.id, 'name', editedName)
+      handleUpdateCategory(category.id, "name", editedName);
     }
-    setIsEditing(false)
-  }
+    setIsEditing(false);
+  };
 
   const onCancel = () => {
     if (category.isTemporary) {
-      handleDeleteCategory(category.id)
+      handleDeleteCategory(category.id);
     } else {
-      setEditedName(category.name)
-      setIsEditing(false)
+      setEditedName(category.name);
+      setIsEditing(false);
     }
-  }
+  };
 
-  const isArabic = currentLanguage === 'ar';
+  const isArabic = currentLanguage === "ar";
 
   const titleStyle = {
     fontFamily: resolveFontFamily(appliedFontSettings.english.font),
@@ -63,34 +78,63 @@ const VintageMenuSection: React.FC<VintageMenuSectionProps> = ({ category, curre
   };
 
   return (
-    <div className="w-full p-4 rounded-lg relative group" dir={isArabic ? 'rtl' : 'ltr'}>
-      <div className={`relative mb-4 flex items-center justify-between ${isArabic ? 'flex-row-reverse' : ''}`}>
-        {isEditing ? (
-          <div className="flex items-center gap-2 flex-grow">
-            <Input 
-              value={editedName} 
-              onChange={(e) => setEditedName(e.target.value)}
-              className="text-lg font-bold uppercase p-0 border-0 border-b-2"
-              style={{...titleStyle, textAlign: isArabic ? 'right' : 'left'}}
-              autoFocus
-            />
-            <Button onClick={onSave} variant="ghost" size="icon"><Save className="w-5 h-5 text-green-600" /></Button>
-            <Button onClick={onCancel} variant="ghost" size="icon"><X className="w-5 h-5 text-red-600" /></Button>
+    <div
+      className="w-full p-4 rounded-lg relative group"
+      dir={isArabic ? "rtl" : "ltr"}
+    >
+      <div
+        className={`relative mb-4 flex items-center justify-between ${isArabic ? "flex-row-reverse" : ""}`}
+      >
+        <h3
+          className="text-lg font-bold uppercase pb-2 border-b-2 flex-grow"
+          style={{ ...titleStyle, textAlign: isArabic ? "right" : "left" }}
+        >
+          {category.name}
+        </h3>
+        {!isPreviewMode && (
+          <div className={`flex items-center ${isArabic ? "mr-2" : "ml-2"}`}>
+            <Button
+              onClick={() => setIsEditing(true)}
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+            >
+              <Edit className="w-4 h-4" />
+            </Button>
+            <Button
+              onClick={() => handleDeleteCategory(category.id)}
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+            >
+              <Trash2 className="w-4 h-4 text-red-500" />
+            </Button>
           </div>
-        ) : (
-          <>
-            <h3 className="text-lg font-bold uppercase pb-2 border-b-2 flex-grow" style={{...titleStyle, textAlign: isArabic ? 'right' : 'left'}}>
-                {category.name}
-            </h3>
-            {!isPreviewMode && (
-              <div className={`flex items-center ${isArabic ? 'mr-2' : 'ml-2'}`}>
-                  <Button onClick={() => setIsEditing(true)} variant="ghost" size="icon" className="h-8 w-8"><Edit className="w-4 h-4" /></Button>
-                  <Button onClick={() => handleDeleteCategory(category.id)} variant="ghost" size="icon" className="h-8 w-8"><Trash2 className="w-4 h-4 text-red-500" /></Button>
-              </div>
-            )}
-          </>
         )}
       </div>
+
+      {isEditing && (
+        <Drawer open={isEditing} onOpenChange={setIsEditing}>
+          <DrawerContent className="p-6 space-y-4">
+            <DrawerHeader>
+              <DrawerTitle>
+                {isArabic ? "تعديل قسم" : "Edit Category"}
+              </DrawerTitle>
+            </DrawerHeader>
+            <Input
+              value={editedName}
+              onChange={(e) => setEditedName(e.target.value)}
+              placeholder={isArabic ? "اسم القسم" : "Category name"}
+            />
+            <DrawerFooter className="flex justify-end gap-2">
+              <Button onClick={onCancel} variant="outline">
+                {isArabic ? "إلغاء" : "Cancel"}
+              </Button>
+              <Button onClick={onSave}>{isArabic ? "حفظ" : "Save"}</Button>
+            </DrawerFooter>
+          </DrawerContent>
+        </Drawer>
+      )}
 
       <div className="space-y-2">
         {category.menu_items.map((item, itemIndex) => (
@@ -99,26 +143,28 @@ const VintageMenuSection: React.FC<VintageMenuSectionProps> = ({ category, curre
             item={item}
             index={itemIndex}
             categoryId={category.id}
-            moveItem={(dragIndex, hoverIndex) => moveItem(category.id, dragIndex, hoverIndex)}
+            moveItem={(dragIndex, hoverIndex) =>
+              moveItem(category.id, dragIndex, hoverIndex)
+            }
             currencySymbol={currencySymbol}
             appliedRowStyles={appliedRowStyles}
           />
         ))}
       </div>
-      
+
       {!isPreviewMode && (
         <div className="mt-4 text-center">
-              <Button 
-                  onClick={() => handleAddItem(category.id)} 
-                  variant="ghost" 
-                  className="text-gray-500 hover:text-gray-800"
-              >
-              <Plus className="w-4 h-4 mr-2" /> Add Item
-              </Button>
+          <Button
+            onClick={() => handleAddItem(category.id)}
+            variant="ghost"
+            className="text-gray-500 hover:text-gray-800"
+          >
+            <Plus className="w-4 h-4 mr-2" /> Add Item
+          </Button>
         </div>
       )}
     </div>
-  )
-}
+  );
+};
 
-export default VintageMenuSection 
+export default VintageMenuSection;

--- a/components/editor/templates/vintage/VintagePreview.tsx
+++ b/components/editor/templates/vintage/VintagePreview.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
-import { useMenuEditor } from '@/contexts/menu-editor-context';
-import VintageMenuSection from './VintageMenuSection';
-import { DndProvider } from 'react-dnd';
-import { HTML5Backend } from 'react-dnd-html5-backend';
-import { ScrollArea } from '@/components/ui/scroll-area';
+import React from "react";
+import { useMenuEditor } from "@/contexts/menu-editor-context";
+import VintageMenuSection from "./VintageMenuSection";
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Button } from "@/components/ui/button";
+import { Plus } from "lucide-react";
 
 const VintagePreview = () => {
   const {
@@ -14,24 +16,25 @@ const VintagePreview = () => {
     rowStyleSettings,
     appliedRowStyles,
     currentLanguage,
+    handleAddCategory,
   } = useMenuEditor();
 
   const getPageBackgroundStyle = () => {
     if (!pageBackgroundSettings) {
-      return { backgroundColor: '#fdfaf3' };
+      return { backgroundColor: "#fdfaf3" };
     }
     switch (pageBackgroundSettings.backgroundType) {
-      case 'gradient':
+      case "gradient":
         return {
           background: `linear-gradient(to bottom right, ${pageBackgroundSettings.gradientFrom}, ${pageBackgroundSettings.gradientTo})`,
         };
-      case 'image':
+      case "image":
         return {
           backgroundImage: `url(${pageBackgroundSettings.backgroundImage})`,
-          backgroundSize: 'cover',
-          backgroundPosition: 'center',
+          backgroundSize: "cover",
+          backgroundPosition: "center",
         };
-      case 'solid':
+      case "solid":
       default:
         return { backgroundColor: pageBackgroundSettings.backgroundColor };
     }
@@ -41,13 +44,15 @@ const VintagePreview = () => {
   const leftColumnCategories = categories.slice(0, middleIndex);
   const rightColumnCategories = categories.slice(middleIndex);
 
-  const isArabic = currentLanguage === 'ar';
-  const activeFontSettings = isArabic ? fontSettings.arabic : fontSettings.english;
-  
-  const fontName = activeFontSettings.font.replace(/\s/g, '_');
-  const headerFontName = isArabic ? 'Cairo' : 'Amiri';
-  
-  const currencySymbol = restaurant?.currency || '$';
+  const isArabic = currentLanguage === "ar";
+  const activeFontSettings = isArabic
+    ? fontSettings.arabic
+    : fontSettings.english;
+
+  const fontName = activeFontSettings.font.replace(/\s/g, "_");
+  const headerFontName = isArabic ? "Cairo" : "Amiri";
+
+  const currencySymbol = restaurant?.currency || "$";
 
   return (
     <DndProvider backend={HTML5Backend}>
@@ -59,9 +64,9 @@ const VintagePreview = () => {
             ...getPageBackgroundStyle(),
             fontFamily: fontName,
             fontWeight: activeFontSettings.weight,
-            color: rowStyleSettings.itemColor || '#3a2d25',
+            color: rowStyleSettings.itemColor || "#3a2d25",
           }}
-          dir={isArabic ? 'rtl' : 'ltr'}
+          dir={isArabic ? "rtl" : "ltr"}
         >
           <header className="text-center mb-12">
             {restaurant?.logo_url ? (
@@ -81,14 +86,16 @@ const VintagePreview = () => {
               className="text-5xl uppercase"
               style={{
                 fontFamily: headerFontName,
-                color: '#3a2d25',
+                color: "#3a2d25",
               }}
             >
-              {restaurant?.name || 'Your Restaurant'}
+              {restaurant?.name || "Your Restaurant"}
             </h1>
           </header>
 
-          <div className={`flex justify-between ${isArabic ? 'flex-row-reverse' : 'flex-row'}`}>
+          <div
+            className={`flex justify-between ${isArabic ? "flex-row-reverse" : "flex-row"}`}
+          >
             <div className="w-[48%]">
               {leftColumnCategories.map((category, index) => (
                 <VintageMenuSection
@@ -110,10 +117,22 @@ const VintagePreview = () => {
               ))}
             </div>
           </div>
+
+          {/* Add Category Button */}
+          <div className="mt-8 text-center">
+            <Button
+              onClick={handleAddCategory}
+              variant="outline"
+              className="border-dashed"
+            >
+              <Plus className="w-4 h-4 mr-2" />
+              {isArabic ? "إضافة قسم جديد" : "Add Category"}
+            </Button>
+          </div>
         </div>
       </ScrollArea>
     </DndProvider>
   );
 };
 
-export default VintagePreview; 
+export default VintagePreview;


### PR DESCRIPTION
## Summary
- add missing Add Category button in `VintagePreview`
- switch vintage category and item editing to a drawer-based form

## Testing
- `npm run test:phase2` *(fails: Cannot find module '../lib/pdf-server-components/template-registry')*
- `npm run test:pdf` *(fails: Cannot find module '../lib/playwright/pdf-generator')*

------
https://chatgpt.com/codex/tasks/task_e_6884b5b5a13883219870b8a89040e796