### PR TITLE
Enhance PDF generation

### DIFF
--- a/app/api/menu-pdf/route.ts
+++ b/app/api/menu-pdf/route.ts
@@ -82,6 +82,7 @@ export async function POST(req: NextRequest) {
         '--disable-setuid-sandbox',
         '--disable-dev-shm-usage',
         '--disable-gpu',
+        '--disable-webgl',
         '--headless',
         '--no-first-run',
         '--disable-extensions',
@@ -96,6 +97,7 @@ export async function POST(req: NextRequest) {
         '--disable-setuid-sandbox',
         '--disable-dev-shm-usage',
         '--disable-gpu',
+        '--disable-webgl',
         '--no-first-run',
         '--no-zygote',
         '--single-process',
@@ -246,10 +248,14 @@ export async function POST(req: NextRequest) {
     console.log('📄 Setting HTML content...');
 
     // Set content with proper wait conditions
-    await page.setContent(cleanHtml, { 
+    await page.setContent(cleanHtml, {
       waitUntil: 'domcontentloaded',
               timeout: parseInt(process.env.PDF_GENERATION_TIMEOUT || '30000')
     });
+
+    try {
+      await page.evaluate(() => document.fonts.ready);
+    } catch {}
 
     console.log('⏱️ Waiting for content to stabilize...');
     

--- a/components/editor/live-menu-editor.tsx
+++ b/components/editor/live-menu-editor.tsx
@@ -367,18 +367,9 @@ export default function LiveMenuEditor({
 
       // Map template names for the Playwright PDF generator
       const getPlaywrightTemplate = (template: string | null) => {
-        switch (template) {
-          case 'classic':
-            return 'cafe';
-          case 'painting':
-            return 'painting';
-          case 'vintage':
-            return 'vintage';
-          case 'modern':
-            return 'modern';
-          default:
-            return 'cafe'; // Default fallback
-        }
+        if (!template) return 'cafe';
+        if (template === 'classic') return 'cafe';
+        return template;
       };
       
       const templateForPlaywright = getPlaywrightTemplate(selectedTemplate);

--- a/lib/html-generator.ts
+++ b/lib/html-generator.ts
@@ -1,5 +1,26 @@
 import { escapeHTML, formatPrice, getSimplifiedCSS } from "@/lib/utils/html-helpers";
 
+function getFontLinks(language: string): string {
+  const systemFonts = language === 'ar'
+    ? '"Segoe UI", "Tahoma", "Arial Unicode MS", sans-serif'
+    : '"Segoe UI", "Roboto", "Helvetica Neue", Arial, sans-serif';
+
+  return `
+    <style>
+      @import url('https://fonts.googleapis.com/css2?family=Cairo:wght@300;400;600;700&family=Inter:wght@300;400;600;700&display=swap');
+      body { font-family: ${systemFonts}; }
+      .font-loaded { font-family: ${language === 'ar' ? "'Cairo'" : "'Inter'"}, ${systemFonts}; }
+    </style>
+    <script>
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = 'https://fonts.googleapis.com/css2?family=Cairo:wght@300;400;600;700&family=Inter:wght@300;400;600;700&display=swap';
+      document.head.appendChild(link);
+      link.onload = () => { document.body.classList.add('font-loaded'); };
+    </script>
+  `;
+}
+
 export function generateSimplifiedHTML(data: any, customizations: any, language: string, templateId: string): string {
   const { restaurant, categories } = data;
   const isRTL = ['ar', 'fa', 'ur', 'he'].includes(language);
@@ -92,6 +113,7 @@ export function generateHTMLContent(options: any): string {
         <style>
           ${customCSS}
         </style>
+        ${getFontLinks(language)}
       </head>
       <body>
           ${menuHTML}

--- a/lib/pdf-server-components/html-template-generator.tsx
+++ b/lib/pdf-server-components/html-template-generator.tsx
@@ -580,7 +580,35 @@ export class HTMLTemplateGenerator {
    * Generate Fast Food template HTML
    */
   private static generateFastFoodTemplate(restaurant: any, categories: any[], currency: string, isRTL: boolean, customizations: any, pageBackgroundStyle: string): string {
-    return this.generateCafeTemplate(restaurant, categories, currency, isRTL, customizations, pageBackgroundStyle)
+    const isEmpty = categories.length === 0
+    const header = `
+      <header style="text-align:center;padding:2rem;background:linear-gradient(90deg,#fef3c7,#fca5a5);border-bottom:4px dashed #dc2626;">
+        <h1 style="font-size:3rem;color:#dc2626;font-weight:900;letter-spacing:0.1em;">${restaurant.name}</h1>
+      </header>
+    `
+
+    const itemsHTML = categories.map(cat => `
+      <section style="margin-bottom:2rem;">
+        <h2 style="color:#b91c1c;font-size:1.5rem;margin-bottom:0.5rem;border-bottom:2px solid #f87171;">${cat.name}</h2>
+        <div>
+          ${cat.menu_items.filter((i:any)=>i.is_available).map((item:any)=>`
+            <div style="display:flex;justify-content:space-between;padding:0.5rem 0;border-bottom:1px dashed #fca5a5;">
+              <span>${item.name}</span>
+              <span>${item.price ? item.price.toFixed(2)+' '+currency : ''}</span>
+            </div>
+          `).join('')}
+        </div>
+      </section>
+    `).join('')
+
+    const content = `
+      ${header}
+      <main style="padding:1.5rem;">
+        ${isEmpty ? '<p style="text-align:center;color:#6b7280;">No items</p>' : itemsHTML}
+      </main>
+    `
+
+    return this.wrapInHTMLDocument(content, pageBackgroundStyle, isRTL)
   }
 
   /**

--- a/lib/playwright/pdf-generator.ts
+++ b/lib/playwright/pdf-generator.ts
@@ -122,6 +122,7 @@ async function getBrowserInstance(): Promise<Browser> {
       '--disable-setuid-sandbox',
       '--disable-dev-shm-usage',
       '--disable-gpu',
+      '--disable-webgl',
       '--no-first-run',
       '--no-zygote',
       '--single-process',
@@ -327,10 +328,18 @@ export class PlaywrightPDFGenerator {
       console.log('📄 Setting HTML content...');
       
       // Set content with proper wait conditions and timeout
-      await page.setContent(htmlContent, { 
+      await page.setContent(htmlContent, {
         waitUntil: 'domcontentloaded',
         timeout: envConfig.pdfTimeout || 30000
       });
+
+      try {
+        await page.evaluate(() => document.fonts.ready);
+      } catch {}
+
+      try {
+        await page.evaluate(() => document.fonts.ready);
+      } catch {}
       
       console.log('⏱️ Waiting for content to stabilize...');
       
@@ -423,6 +432,9 @@ export class PlaywrightPDFGenerator {
         timeout: envConfig.pdfTimeout || 30000
       });
 
+      try {
+        await page.evaluate(() => document.fonts.ready);
+      } catch {}
       // Wait for network idle with fallback
       await Promise.race([
         page.waitForLoadState('networkidle', { timeout: 10000 }),


### PR DESCRIPTION
## Summary
- add async font loading helper for generated HTML
- improve Fast Food HTML template design
- simplify template mapping
- disable WebGL when launching Chromium
- wait for fonts to load in Playwright generator and API

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'react')*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68846ea82e408321b45834fb315b3bfa