### PR TITLE
Add unified modern-coffee template

### DIFF
--- a/app/api/menu-pdf/generate/route.ts
+++ b/app/api/menu-pdf/generate/route.ts
@@ -110,7 +110,7 @@ export async function POST(request: NextRequest) {
 
     try {
       // Step 1: Render template to HTML (with timeout)
-      const renderPromise = PDFReactRenderer.renderTemplate(renderOptions)
+      const renderPromise = PDFReactRenderer.renderTemplateWithReact(renderOptions)
       const timeoutPromise = new Promise<never>((_, reject) => {
         setTimeout(() => reject(new Error('Template rendering timeout')), 30000)
       })
@@ -143,7 +143,7 @@ export async function POST(request: NextRequest) {
         console.log('🔄 Attempting browser reset and retry...')
         await resetBrowserInstance()
         
-        const retryHtmlContent = await PDFReactRenderer.renderTemplate(renderOptions)
+        const retryHtmlContent = await PDFReactRenderer.renderTemplateWithReact(renderOptions)
         pdfBuffer = await generatePDFFromMenuData({
           htmlContent: retryHtmlContent,
           format: format as 'A4' | 'Letter',

--- a/components/editor/live-menu-editor.tsx
+++ b/components/editor/live-menu-editor.tsx
@@ -811,7 +811,7 @@ export default function LiveMenuEditor({
                 return <InteractiveMenuPreview key={selectedTemplate} menu={categories} onUpdateMenu={() => {}} />;
               }
               case 'modern-coffee': {
-                const ModernCoffeePreview = require("@/components/editor/templates/modern-coffee/ModernCoffeePreview").default;
+                const ModernCoffeePreview = require("@/components/editor/templates/modern-coffee/ModernCoffeePreviewUnified").default;
                 return <ModernCoffeePreview key={selectedTemplate} />;
               }
               case 'painting': {

--- a/components/editor/templates/modern-coffee/ModernCoffeePreviewUnified.tsx
+++ b/components/editor/templates/modern-coffee/ModernCoffeePreviewUnified.tsx
@@ -1,0 +1,81 @@
+import React from 'react'
+import { useMenuEditor } from '@/contexts/menu-editor-context'
+import { DndProvider } from 'react-dnd'
+import { HTML5Backend } from 'react-dnd-html5-backend'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { Button } from '@/components/ui/button'
+import { Plus } from 'lucide-react'
+import { UnifiedTemplateBase, UnifiedTemplateProps } from '@/components/shared/unified-template-base'
+import { SharedFontSettings } from '@/components/shared/menu-components'
+
+/**
+ * Unified Modern Coffee Preview Component
+ * Uses the same shared components as PDF templates for perfect consistency
+*/
+const ModernCoffeePreviewUnified: React.FC = () => {
+  const {
+    categories,
+    restaurant,
+    pageBackgroundSettings,
+    fontSettings,
+    rowStyleSettings,
+    appliedRowStyles,
+    currentLanguage,
+    moveItem,
+    handleAddCategory,
+  } = useMenuEditor()
+
+  const handleAddCategoryClick = () => {
+    handleAddCategory()
+  }
+
+  // Convert context data to unified template props
+  const unifiedProps: UnifiedTemplateProps = {
+    restaurant: {
+      id: restaurant?.id || '',
+      name: restaurant?.name || '',
+      category: restaurant?.category || '',
+      logo_url: restaurant?.logo_url || undefined,
+      address: restaurant?.address || undefined,
+      phone: restaurant?.phone || undefined,
+      website: restaurant?.website || undefined,
+      color_palette: restaurant?.color_palette || undefined,
+      currency: restaurant?.currency || undefined
+    },
+    categories: categories || [],
+    language: currentLanguage,
+    fontSettings: fontSettings as SharedFontSettings,
+    customizations: {
+      pageBackgroundSettings,
+      rowStyles: rowStyleSettings
+    },
+    isPdfGeneration: false,
+    isPreview: true,
+    showFooter: true,
+    showImages: true
+  }
+
+  return (
+    <DndProvider backend={HTML5Backend}>
+      <ScrollArea className="h-full w-full">
+        <div className="relative">
+          {/* Unified Template Base */}
+          <UnifiedTemplateBase {...unifiedProps} />
+          
+          {/* Preview-specific controls */}
+          <div className="absolute bottom-4 right-4 z-10">
+            <Button
+              onClick={handleAddCategoryClick}
+              className="bg-gradient-to-r from-blue-500 to-purple-500 hover:from-blue-600 hover:to-purple-600 text-white font-medium px-6 py-2 rounded-lg shadow-lg transition-all duration-200 transform hover:scale-105"
+            >
+              <Plus className="w-4 h-4 mr-2" />
+              {currentLanguage === 'ar' ? 'إضافة قسم' : 'Add Category'}
+            </Button>
+          </div>
+        </div>
+      </ScrollArea>
+    </DndProvider>
+  )
+}
+
+export default ModernCoffeePreviewUnified

--- a/components/template-preview-renderer.tsx
+++ b/components/template-preview-renderer.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react'
 // Import client-side preview components instead of server-side PDF components
 import ModernPreview from '@/components/editor/templates/modern/ModernPreview'
-import ModernCoffeePreview from '@/components/editor/templates/modern-coffee/ModernCoffeePreview'
+import ModernCoffeePreviewUnified from '@/components/editor/templates/modern-coffee/ModernCoffeePreviewUnified'
 import VintagePreview from '@/components/editor/templates/vintage/VintagePreview'
 import PaintingStylePreview from '@/components/editor/templates/painting-style/PaintingStylePreview'
 import ModernPreviewUnified from '@/components/editor/templates/modern/ModernPreviewUnified'
@@ -96,14 +96,14 @@ const previewComponents: Record<string, React.ComponentType<any>> = {
   'classic': ModernPreview,
   'cafe': ModernPreview,
   'modern': ModernPreview,
-  'modern-coffee': ModernCoffeePreview,
+  'modern-coffee': ModernCoffeePreviewUnified,
   'painting': PaintingStylePreview,
   'vintage': VintagePreview,
   'fast-food': ModernPreview,
   'elegant-cocktail': ModernPreview,
   'sweet-treats': ModernPreview,
-  'simple-coffee': ModernCoffeePreview,
-  'borcelle-coffee': ModernCoffeePreview,
+  'simple-coffee': ModernCoffeePreviewUnified,
+  'borcelle-coffee': ModernCoffeePreviewUnified,
   'luxury-menu': ModernPreview,
   'chalkboard-coffee': ModernPreview,
   'botanical-cafe': ModernPreview,

--- a/data/pdf-templates-metadata.json
+++ b/data/pdf-templates-metadata.json
@@ -169,8 +169,8 @@
       "id": "modern-coffee",
       "name": "Modern Coffee Shop",
       "description": "Warm orange tones with coffee elements and modern design",
-      "componentPath": "./templates/ModernCoffeePDFTemplate",
-      "previewComponentPath": "../components/editor/templates/modern-coffee-preview",
+      "componentPath": "./templates/ModernCoffeePDFTemplateUnified",
+      "previewComponentPath": "../components/editor/templates/modern-coffee/ModernCoffeePreviewUnified",
       "category": "coffee",
       "features": [
         "header",

--- a/lib/client-template-registry.ts
+++ b/lib/client-template-registry.ts
@@ -145,9 +145,11 @@ export class ClientTemplateRegistryService {
     // Map server component names to client component names
     const componentMapping: Record<string, string> = {
       'ModernPDFTemplate': 'ModernTemplate',
+      'ModernPDFTemplateUnified': 'ModernTemplate',
       'PaintingStylePDFTemplate': 'PaintingTemplate',
       'VintagePDFTemplate': 'VintageTemplate',
       'ModernCoffeePDFTemplate': 'ModernCoffeeTemplate',
+      'ModernCoffeePDFTemplateUnified': 'ModernCoffeeTemplate',
       'CafePDFTemplate': 'CafeTemplate',
       'FastFoodPDFTemplate': 'FastFoodTemplate',
       'ElegantCocktailPDFTemplate': 'ElegantCocktailTemplate',

--- a/lib/pdf-server-components/templates/ModernCoffeePDFTemplateUnified.tsx
+++ b/lib/pdf-server-components/templates/ModernCoffeePDFTemplateUnified.tsx
@@ -1,0 +1,108 @@
+import React from 'react'
+import { UnifiedTemplateBase, UnifiedTemplateProps } from '@/components/shared/unified-template-base'
+import { SharedFontSettings } from '@/components/shared/menu-components'
+
+interface MenuItem {
+  id: string
+  name: string
+  description: string | null
+  price: number | null
+  image_url: string | null
+  is_available: boolean
+  is_featured: boolean
+  dietary_info: string[]
+}
+
+interface MenuCategory {
+  id: string
+  name: string
+  description: string | null
+  menu_items: MenuItem[]
+}
+
+interface Restaurant {
+  id: string
+  name: string
+  category: string
+  logo_url: string | null
+  address?: string | null
+  phone?: string | null
+  website?: string | null
+  color_palette?: {
+    primary: string
+    secondary: string
+    accent: string
+  } | null
+  currency?: string
+}
+
+interface ModernCoffeePDFTemplateUnifiedProps {
+  restaurant: Restaurant
+  categories: MenuCategory[]
+  language?: string
+  customizations?: {
+    fontSettings?: SharedFontSettings
+    pageBackgroundSettings?: any
+    rowStyles?: any
+  }
+}
+
+/**
+ * Unified Modern Coffee PDF Template Component
+ * Uses the same shared components as the preview for perfect consistency
+ * This ensures that the PDF output matches exactly what users see in the preview
+ */
+export function ModernCoffeePDFTemplateUnified({
+  restaurant,
+  categories,
+  language = 'ar',
+  customizations = {}
+}: ModernCoffeePDFTemplateUnifiedProps) {
+  
+  // Convert props to unified template format
+  const unifiedProps: UnifiedTemplateProps = {
+    restaurant: {
+      id: restaurant.id,
+      name: restaurant.name,
+      category: restaurant.category,
+      logo_url: restaurant.logo_url,
+      address: restaurant.address,
+      phone: restaurant.phone,
+      website: restaurant.website,
+      color_palette: restaurant.color_palette,
+      currency: restaurant.currency
+    },
+    categories: categories.map(category => ({
+      id: category.id,
+      name: category.name,
+      description: category.description,
+      menu_items: category.menu_items.map(item => ({
+        id: item.id,
+        name: item.name,
+        description: item.description,
+        price: item.price,
+        image_url: item.image_url,
+        is_available: item.is_available,
+        is_featured: item.is_featured,
+        dietary_info: item.dietary_info
+      }))
+    })),
+    language,
+    fontSettings: customizations.fontSettings || {
+      arabic: { font: 'Cairo', weight: 'normal' },
+      english: { font: 'Roboto', weight: 'normal' }
+    },
+    customizations: {
+      pageBackgroundSettings: customizations.pageBackgroundSettings,
+      rowStyles: customizations.rowStyles
+    },
+    isPdfGeneration: true,
+    isPreview: false,
+    showFooter: true,
+    showImages: true
+  }
+
+  return <UnifiedTemplateBase {...unifiedProps} />
+}
+
+export default ModernCoffeePDFTemplateUnified

--- a/public/data/pdf-templates-metadata.json
+++ b/public/data/pdf-templates-metadata.json
@@ -169,8 +169,8 @@
       "id": "modern-coffee",
       "name": "Modern Coffee Shop",
       "description": "Warm orange tones with coffee elements and modern design",
-      "componentPath": "./templates/ModernCoffeePDFTemplate",
-      "previewComponentPath": "../components/editor/templates/modern-coffee-preview",
+      "componentPath": "./templates/ModernCoffeePDFTemplateUnified",
+      "previewComponentPath": "../components/editor/templates/modern-coffee/ModernCoffeePreviewUnified",
       "category": "coffee",
       "features": [
         "header",


### PR DESCRIPTION
## Summary
- implement unified preview and PDF components for the modern coffee template
- update preview renderer and live editor to use unified component
- register unified components in template metadata
- map unified components in client registry
- render templates via React for PDF generation

## Testing
- `npm run lint` *(fails: interactive prompt)*
- `npm run build` *(fails: blocked network requests for fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68886ea81608832192306cac999ed4ef