### PR TITLE
refactor cocktail menu base

### DIFF
--- a/components/templates/CocktailMenuBase.tsx
+++ b/components/templates/CocktailMenuBase.tsx
@@ -1,0 +1,151 @@
+import React from 'react'
+
+export interface CocktailMenuBaseProps {
+  restaurant: any
+  categories: any[]
+  language?: string
+  customizations?: any
+  isPreview?: boolean
+  isPdfGeneration?: boolean
+}
+
+// SVG Illustrations for cocktail theme
+const CocktailGlassIllustration = () => (
+  <svg width="80" height="120" viewBox="0 0 80 120" className="text-white">
+    <g fill="none" stroke="currentColor" strokeWidth="2">
+      {/* Martini glass */}
+      <path d="M20 30 L60 30 L40 60 L40 90" />
+      <ellipse cx="40" cy="95" rx="15" ry="3" />
+
+      {/* Liquid */}
+      <path d="M25 35 L55 35 L40 55 Z" fill="currentColor" fillOpacity="0.2" />
+
+      {/* Garnish */}
+      <circle cx="35" cy="40" r="2" fill="currentColor" />
+      <circle cx="45" cy="42" r="1.5" fill="currentColor" />
+
+      {/* Bubbles */}
+      <circle cx="38" cy="45" r="1" fill="currentColor" fillOpacity="0.3" />
+      <circle cx="42" cy="48" r="0.8" fill="currentColor" fillOpacity="0.3" />
+      <circle cx="40" cy="52" r="0.6" fill="currentColor" fillOpacity="0.3" />
+    </g>
+  </svg>
+)
+
+const CitrusSliceIllustration = () => (
+  <svg width="80" height="80" viewBox="0 0 80 80" className="text-white">
+    <g fill="none" stroke="currentColor" strokeWidth="1.5">
+      {/* Orange slice */}
+      <circle cx="40" cy="40" r="25" fill="currentColor" fillOpacity="0.1" />
+      <circle cx="40" cy="40" r="25" />
+
+      {/* Segments */}
+      <line x1="40" y1="15" x2="40" y2="65" />
+      <line x1="15" y1="40" x2="65" y2="40" />
+      <line x1="22" y1="22" x2="58" y2="58" />
+      <line x1="58" y1="22" x2="22" y2="58" />
+
+      {/* Center */}
+      <circle cx="40" cy="40" r="3" fill="currentColor" fillOpacity="0.3" />
+
+      {/* Texture details */}
+      <g strokeWidth="0.8" opacity="0.6">
+        <path d="M30 25 Q35 30 40 25" />
+        <path d="M50 25 Q45 30 40 25" />
+        <path d="M55 35 Q50 40 55 45" />
+        <path d="M25 35 Q30 40 25 45" />
+      </g>
+    </g>
+  </svg>
+)
+
+const CocktailShakerIllustration = () => (
+  <svg width="60" height="120" viewBox="0 0 60 120" className="text-white">
+    <g fill="none" stroke="currentColor" strokeWidth="2">
+      {/* Shaker body */}
+      <rect x="15" y="30" width="30" height="60" rx="5" fill="currentColor" fillOpacity="0.1" />
+      <rect x="15" y="30" width="30" height="60" rx="5" />
+
+      {/* Shaker top */}
+      <rect x="18" y="20" width="24" height="15" rx="3" fill="currentColor" fillOpacity="0.1" />
+      <rect x="18" y="20" width="24" height="15" rx="3" />
+
+      {/* Cap */}
+      <rect x="20" y="15" width="20" height="8" rx="2" fill="currentColor" fillOpacity="0.2" />
+      <rect x="20" y="15" width="20" height="8" rx="2" />
+
+      {/* Details */}
+      <line x1="15" y1="45" x2="45" y2="45" strokeWidth="1" />
+      <line x1="15" y1="60" x2="45" y2="60" strokeWidth="1" />
+      <line x1="15" y1="75" x2="45" y2="75" strokeWidth="1" />
+
+      {/* Handle */}
+      <path d="M45 50 Q55 50 55 60 Q55 70 45 70" strokeWidth="1.5" />
+    </g>
+  </svg>
+)
+
+export function CocktailMenuBase({ categories }: CocktailMenuBaseProps) {
+  return (
+    <div className="min-h-screen bg-gray-100 flex">
+      {/* Black Sidebar with Illustrations */}
+      <div className="w-80 bg-black flex flex-col items-center justify-center space-y-12 p-8">
+        <CocktailGlassIllustration />
+        <CitrusSliceIllustration />
+        <CocktailShakerIllustration />
+      </div>
+
+      {/* Main Content */}
+      <div className="flex-1 p-12">
+        {/* Header */}
+        <div className="mb-16">
+          <h1 className="text-7xl font-black text-gray-900 tracking-tight mb-4">COCKTAIL</h1>
+        </div>
+
+        {/* Menu Categories */}
+        <div className="space-y-12">
+          {categories.map((category: any) => (
+            <div key={category.id} className="relative">
+              {/* Category Header */}
+              <h2 className="text-4xl font-bold text-gray-900 tracking-wide mb-8">
+                {category.name.toUpperCase()}
+              </h2>
+
+              {/* Menu Items */}
+              <div className="space-y-6">
+                {category.menu_items.map((item: any) => (
+                  <div key={item.id} className="flex justify-between items-start">
+                    <div className="flex-1">
+                      <h3 className="text-xl font-bold text-gray-900 mb-1 tracking-wide">
+                        {item.name.toUpperCase()}
+                      </h3>
+                      {item.description && (
+                        <p className="text-gray-700 text-lg leading-relaxed">
+                          {item.description}
+                        </p>
+                      )}
+                    </div>
+                    <div className="ml-8 flex-shrink-0">
+                      <span className="text-3xl font-bold text-gray-900">
+                        ${item.price?.toFixed(2) || '0.00'}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Footer */}
+        <div className="mt-20">
+          <p className="text-2xl text-gray-800 font-light">
+            You'd rather drink than worry!
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default CocktailMenuBase

--- a/components/templates/cocktail-menu-preview.tsx
+++ b/components/templates/cocktail-menu-preview.tsx
@@ -1,138 +1,33 @@
 "use client"
 
 import { useMenuEditor } from '@/contexts/menu-editor-context'
-import { getPDFGenerationMode } from '@/lib/pdf-server-components/pdf-template-factory'
+import { CocktailMenuBase } from './CocktailMenuBase'
 
-// SVG Illustrations for cocktail theme
-const CocktailGlassIllustration = () => (
-  <svg width="80" height="120" viewBox="0 0 80 120" className="text-white">
-    <g fill="none" stroke="currentColor" strokeWidth="2">
-      {/* Martini glass */}
-      <path d="M20 30 L60 30 L40 60 L40 90" />
-      <ellipse cx="40" cy="95" rx="15" ry="3" />
+export default function CocktailMenuPreview() {
+  const {
+    restaurant,
+    categories,
+    currentLanguage,
+    appliedFontSettings,
+    appliedPageBackgroundSettings,
+    appliedRowStyles,
+  } = useMenuEditor()
 
-      {/* Liquid */}
-      <path d="M25 35 L55 35 L40 55 Z" fill="currentColor" fillOpacity="0.2" />
-
-      {/* Garnish */}
-      <circle cx="35" cy="40" r="2" fill="currentColor" />
-      <circle cx="45" cy="42" r="1.5" fill="currentColor" />
-
-      {/* Bubbles */}
-      <circle cx="38" cy="45" r="1" fill="currentColor" fillOpacity="0.3" />
-      <circle cx="42" cy="48" r="0.8" fill="currentColor" fillOpacity="0.3" />
-      <circle cx="40" cy="52" r="0.6" fill="currentColor" fillOpacity="0.3" />
-    </g>
-  </svg>
-);
-
-const CitrusSliceIllustration = () => (
-  <svg width="80" height="80" viewBox="0 0 80 80" className="text-white">
-    <g fill="none" stroke="currentColor" strokeWidth="1.5">
-      {/* Orange slice */}
-      <circle cx="40" cy="40" r="25" fill="currentColor" fillOpacity="0.1" />
-      <circle cx="40" cy="40" r="25" />
-
-      {/* Segments */}
-      <line x1="40" y1="15" x2="40" y2="65" />
-      <line x1="15" y1="40" x2="65" y2="40" />
-      <line x1="22" y1="22" x2="58" y2="58" />
-      <line x1="58" y1="22" x2="22" y2="58" />
-
-      {/* Center */}
-      <circle cx="40" cy="40" r="3" fill="currentColor" fillOpacity="0.3" />
-
-      {/* Texture details */}
-      <g strokeWidth="0.8" opacity="0.6">
-        <path d="M30 25 Q35 30 40 25" />
-        <path d="M50 25 Q45 30 40 25" />
-        <path d="M55 35 Q50 40 55 45" />
-        <path d="M25 35 Q30 40 25 45" />
-      </g>
-    </g>
-  </svg>
-);
-
-const CocktailShakerIllustration = () => (
-  <svg width="60" height="120" viewBox="0 0 60 120" className="text-white">
-    <g fill="none" stroke="currentColor" strokeWidth="2">
-      {/* Shaker body */}
-      <rect x="15" y="30" width="30" height="60" rx="5" fill="currentColor" fillOpacity="0.1" />
-      <rect x="15" y="30" width="30" height="60" rx="5" />
-
-      {/* Shaker top */}
-      <rect x="18" y="20" width="24" height="15" rx="3" fill="currentColor" fillOpacity="0.1" />
-      <rect x="18" y="20" width="24" height="15" rx="3" />
-
-      {/* Cap */}
-      <rect x="20" y="15" width="20" height="8" rx="2" fill="currentColor" fillOpacity="0.2" />
-      <rect x="20" y="15" width="20" height="8" rx="2" />
-
-      {/* Details */}
-      <line x1="15" y1="45" x2="45" y2="45" strokeWidth="1" />
-      <line x1="15" y1="60" x2="45" y2="60" strokeWidth="1" />
-      <line x1="15" y1="75" x2="45" y2="75" strokeWidth="1" />
-
-      {/* Handle */}
-      <path d="M45 50 Q55 50 55 60 Q55 70 45 70" strokeWidth="1.5" />
-    </g>
-  </svg>
-);
-
-export function CocktailMenuPreview() {
-  const { categories } = useMenuEditor()
+  const customizations = {
+    fontSettings: appliedFontSettings,
+    pageBackgroundSettings: appliedPageBackgroundSettings,
+    rowStyles: appliedRowStyles,
+  }
 
   return (
-    <div className="min-h-screen bg-gray-100 flex">
-      {/* Black Sidebar with Illustrations */}
-      <div className="w-80 bg-black flex flex-col items-center justify-center space-y-12 p-8">
-        <CocktailGlassIllustration />
-        <CitrusSliceIllustration />
-        <CocktailShakerIllustration />
-      </div>
-
-      {/* Main Content */}
-      <div className="flex-1 p-12">
-        {/* Header */}
-        <div className="mb-16">
-          <h1 className="text-7xl font-black text-gray-900 tracking-tight mb-4">COCKTAIL</h1>
-        </div>
-
-        {/* Menu Categories */}
-        <div className="space-y-12">
-          {categories.map((category) => (
-            <div key={category.id} className="relative">
-              {/* Category Header */}
-              <h2 className="text-4xl font-bold text-gray-900 tracking-wide mb-8">{category.name.toUpperCase()}</h2>
-
-              {/* Menu Items */}
-              <div className="space-y-6">
-                {category.menu_items.map((item) => (
-                  <div key={item.id} className="flex justify-between items-start">
-                    <div className="flex-1">
-                      <h3 className="text-xl font-bold text-gray-900 mb-1 tracking-wide">{item.name.toUpperCase()}</h3>
-                      {item.description && <p className="text-gray-700 text-lg leading-relaxed">{item.description}</p>}
-                    </div>
-                    <div className="ml-8 flex-shrink-0">
-                      <span className="text-3xl font-bold text-gray-900">
-                        ${item.price?.toFixed(2) || '0.00'}
-                      </span>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          ))}
-        </div>
-
-        {/* Footer */}
-        <div className="mt-20">
-          <p className="text-2xl text-gray-800 font-light">You'd rather drink than worry!</p>
-        </div>
-      </div>
-    </div>
+    <CocktailMenuBase
+      restaurant={restaurant}
+      categories={categories}
+      language={currentLanguage}
+      customizations={customizations}
+      isPreview
+    />
   )
 }
 
-// Add default export for template registry compatibility
-export default CocktailMenuPreview
+export { CocktailMenuBase } from './CocktailMenuBase'

--- a/lib/pdf-server-components/pdf-template-factory.tsx
+++ b/lib/pdf-server-components/pdf-template-factory.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { templateRegistry, TemplateMetadata } from './template-registry'
-import { MenuEditorProvider } from '@/contexts/menu-editor-context'
 
 // Global flag to indicate PDF generation mode
 let isPDFGenerationMode = false
@@ -108,18 +107,13 @@ export class PDFTemplateFactory {
       // Load template component dynamically  
       const TemplateComponent = await templateRegistry.loadTemplateComponent(normalizedId)
       
-      // Create the template element with a wrapper that provides context data
-      const templateElement = React.createElement(
-        PDFTemplateContextProvider,
-        {
-          restaurant: props.restaurant,
-          categories: props.categories,
-          language: props.language,
-          customizations: props.customizations,
-          children: React.createElement(TemplateComponent)
-        }
-      )
-      
+      // Directly render the template component with supplied props
+      const templateElement = React.createElement(TemplateComponent, {
+        ...props,
+        isPdfGeneration: true,
+        isPreview: false,
+      })
+
       return templateElement
     } catch (error) {
       console.error(`❌ Error creating template ${templateId}:`, error)
@@ -264,47 +258,4 @@ export const DynamicPDFTemplate: React.FC<{
   return React.createElement(TemplateComponent, props)
 }
 
-/**
- * PDF Context provider that wraps templates with MenuEditorProvider
- * This ensures templates get all the context data they need
- */
-const PDFTemplateContextProvider: React.FC<{
-  restaurant: Restaurant
-  categories: MenuCategory[]
-  language?: string
-  customizations?: any
-  children: React.ReactNode
-}> = ({ restaurant, categories, language, customizations, children }) => {
-  // Create a proper MenuEditorProvider with the PDF data
-  const contextRestaurant = {
-    ...restaurant,
-    // Ensure color_palette has the right structure for context
-    color_palette: restaurant.color_palette ? {
-      id: 'pdf-palette',
-      name: 'PDF Palette',
-      ...restaurant.color_palette
-    } : null,
-    // Ensure address/phone/website are properly typed
-    address: restaurant.address || undefined,
-    phone: restaurant.phone || undefined,
-    website: restaurant.website || undefined,
-  }
-
-  return React.createElement(
-    MenuEditorProvider,
-    {
-      restaurant: contextRestaurant as any, // Type cast to avoid complex type issues
-      initialCategories: categories,
-      onRefresh: () => {}, // No-op for PDF generation
-      children: React.createElement('div', { 
-        'data-pdf-mode': 'true',
-        style: { 
-          width: '100%', 
-          height: '100%' 
-        }
-      }, children)
-    }
-  )
-}
-
-export default PDFTemplateFactory 
+export default PDFTemplateFactory

--- a/lib/pdf-server-components/template-registry.ts
+++ b/lib/pdf-server-components/template-registry.ts
@@ -9,7 +9,7 @@ const templateImporters: Record<string, () => Promise<any>> = {
   'borcelle-coffee': () => import('@/components/templates/borcelle-coffee-preview'),
   'botanical-cafe': () => import('@/components/templates/botanical-cafe-preview'),
   'chalkboard-coffee': () => import('@/components/templates/chalkboard-coffee-preview'),
-  'cocktail-menu': () => import('@/components/templates/cocktail-menu-preview'),
+  'cocktail-menu': () => import('@/lib/pdf-server-components/templates/CocktailMenuPDFTemplate'),
   'elegant-cocktail': () => import('@/components/templates/elegant-cocktail-menu-preview'),
   'fast-food': () => import('@/components/templates/fast-food-menu-preview'),
   'interactive-menu': () => import('@/components/templates/interactive-menu-preview'),

--- a/lib/pdf-server-components/templates/CocktailMenuPDFTemplate.tsx
+++ b/lib/pdf-server-components/templates/CocktailMenuPDFTemplate.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import { CocktailMenuBase, CocktailMenuBaseProps } from '@/components/templates/CocktailMenuBase'
+
+export function CocktailMenuPDFTemplate(props: CocktailMenuBaseProps) {
+  return <CocktailMenuBase {...props} isPreview={false} isPdfGeneration />
+}
+
+export default CocktailMenuPDFTemplate


### PR DESCRIPTION
## Summary
- extract server-safe CocktailMenuBase component and use it in client preview wrapper
- add server PDF wrapper and registry entry for cocktail menu
- simplify PDFTemplateFactory to render templates directly without context providers

## Testing
- `pnpm lint` *(fails: Command failed with exit code 1)*
- `node -e "require('ts-node/register'); const { PDFReactRenderer } = require('./lib/pdf-server-components/pdf-renderer'); (async()=>{ const html = await PDFReactRenderer.renderTemplateWithReact({ templateId:'cocktail-menu', restaurant:{id:'1',name:'Test',category:'bar',logo_url:null}, categories:[{id:'c1',name:'Drinks',description:null,menu_items:[{id:'i1',name:'Martini',description:'',price:12,image_url:null,is_available:true,is_featured:false,dietary_info:[]}]}], language:'en', customizations:{} }); console.log(html.substring(0,60)); })();"` *(fails: Cannot find module '/workspace/menu-p/lib/pdf-server-components/html-template-generator')*


------
https://chatgpt.com/codex/tasks/task_e_688dc62a7cc48321b17b4d79b1c5e995