### PR TITLE
Align PDF templates with preview styles

### DIFF
--- a/components/templates/luxury-menu-preview.tsx
+++ b/components/templates/luxury-menu-preview.tsx
@@ -245,10 +245,10 @@ export function LuxuryMenuPreview({ menu, onUpdateMenu }: LuxuryMenuPreviewProps
             {/* Menu Header */}
             <div className="text-center mb-16">
               <div className="mb-6">
-                <h1 className="text-6xl font-serif text-yellow-400 mb-2 tracking-wider">
+                <h1 className="text-6xl font-serif text-[#d4af37] mb-2 tracking-wider">
                   <span className="font-script text-7xl">Think</span>
                 </h1>
-                <h2 className="text-5xl font-serif text-yellow-400 tracking-[0.3em] font-light">UNLIMITED</h2>
+                <h2 className="text-5xl font-serif text-[#d4af37] tracking-[0.3em] font-light">UNLIMITED</h2>
               </div>
               <div className="text-yellow-200/80 text-lg tracking-[0.2em] font-light mb-6">A TASTE OF COMFORT</div>
               {/* Decorative Divider */}
@@ -287,13 +287,13 @@ export function LuxuryMenuPreview({ menu, onUpdateMenu }: LuxuryMenuPreviewProps
                                     {...provided.dragHandleProps}
                                     className="cursor-grab p-1 hover:bg-yellow-600/20 rounded bg-yellow-600/10"
                                   >
-                                    <GripVertical className="w-4 h-4 text-yellow-400/70" />
+                                    <GripVertical className="w-4 h-4 text-[#d4af37]/70" />
                                   </div>
                                   <Button
                                     size="sm"
                                     variant="ghost"
                                     onClick={() => toggleSpecialCategory(category.id, category.isSpecial || false)}
-                                    className="h-6 w-6 p-0 text-yellow-400/70 hover:text-yellow-400 hover:bg-yellow-600/20 bg-yellow-600/10"
+                                    className="h-6 w-6 p-0 text-[#d4af37]/70 hover:text-[#d4af37] hover:bg-yellow-600/20 bg-yellow-600/10"
                                   >
                                     <Sparkles className="w-3 h-3" />
                                   </Button>
@@ -301,7 +301,7 @@ export function LuxuryMenuPreview({ menu, onUpdateMenu }: LuxuryMenuPreviewProps
                                     size="sm"
                                     variant="ghost"
                                     onClick={() => startEditingCategory(category.id, category.name)}
-                                    className="h-6 w-6 p-0 text-yellow-400/70 hover:text-yellow-400 hover:bg-yellow-600/20 bg-yellow-600/10"
+                                    className="h-6 w-6 p-0 text-[#d4af37]/70 hover:text-[#d4af37] hover:bg-yellow-600/20 bg-yellow-600/10"
                                   >
                                     <Edit className="w-3 h-3" />
                                   </Button>
@@ -309,7 +309,7 @@ export function LuxuryMenuPreview({ menu, onUpdateMenu }: LuxuryMenuPreviewProps
                                     size="sm"
                                     variant="ghost"
                                     onClick={() => deleteCategory(category.id)}
-                                    className="h-6 w-6 p-0 text-yellow-400/70 hover:text-red-400 hover:bg-red-500/20 bg-yellow-600/10"
+                                    className="h-6 w-6 p-0 text-[#d4af37]/70 hover:text-red-400 hover:bg-red-500/20 bg-yellow-600/10"
                                   >
                                     <Trash2 className="w-3 h-3" />
                                   </Button>
@@ -317,7 +317,7 @@ export function LuxuryMenuPreview({ menu, onUpdateMenu }: LuxuryMenuPreviewProps
                                     size="sm"
                                     variant="ghost"
                                     onClick={() => addItem(category.id)}
-                                    className="h-6 w-6 p-0 text-yellow-400/70 hover:text-yellow-400 hover:bg-yellow-600/20 bg-yellow-600/10"
+                                    className="h-6 w-6 p-0 text-[#d4af37]/70 hover:text-[#d4af37] hover:bg-yellow-600/20 bg-yellow-600/10"
                                   >
                                     <Plus className="w-3 h-3" />
                                   </Button>
@@ -334,14 +334,14 @@ export function LuxuryMenuPreview({ menu, onUpdateMenu }: LuxuryMenuPreviewProps
                                         if (e.key === "Enter") saveCategory()
                                         if (e.key === "Escape") cancelEditingCategory()
                                       }}
-                                      className="text-2xl font-serif font-bold bg-yellow-600/20 border-yellow-600/50 text-yellow-400 tracking-wider"
+                                      className="text-2xl font-serif font-bold bg-yellow-600/20 border-yellow-600/50 text-[#d4af37] tracking-wider"
                                       autoFocus
                                     />
                                   </div>
                                 ) : (
                                   <div className="mb-4">
                                     <h3
-                                      className="text-2xl font-serif font-bold text-yellow-400 tracking-wider cursor-pointer hover:text-yellow-300 transition-colors"
+                                      className="text-2xl font-serif font-bold text-[#d4af37] tracking-wider cursor-pointer hover:text-yellow-300 transition-colors"
                                       onClick={() =>
                                         isPreviewMode && startEditingCategory(category.id, category.name)
                                       }
@@ -383,7 +383,7 @@ export function LuxuryMenuPreview({ menu, onUpdateMenu }: LuxuryMenuPreviewProps
                                                           : "opacity-0 translate-x-4 pointer-events-none"
                                                       }`}
                                                     >
-                                                      <GripVertical className="w-3 h-3 text-yellow-400/50" />
+                                                      <GripVertical className="w-3 h-3 text-[#d4af37]/50" />
                                                     </div>
                                                     {editingItemId === item.id ? (
                                                       <input
@@ -397,7 +397,7 @@ export function LuxuryMenuPreview({ menu, onUpdateMenu }: LuxuryMenuPreviewProps
                                                           )
                                                         }
                                                         onBlur={() => setEditingItemId(null)}
-                                                        className="text-lg font-serif font-semibold text-yellow-200 bg-transparent border-b border-yellow-600/50 focus:border-yellow-400 outline-none"
+                                                        className="text-lg font-serif font-semibold text-yellow-200 bg-transparent border-b border-yellow-600/50 focus:border-[#d4af37] outline-none"
                                                         autoFocus
                                                       />
                                                     ) : (
@@ -417,7 +417,7 @@ export function LuxuryMenuPreview({ menu, onUpdateMenu }: LuxuryMenuPreviewProps
                                                         )
                                                       }
                                                       onBlur={() => setEditingItemId(null)}
-                                                      className="text-sm text-yellow-100/80 leading-relaxed bg-transparent border-b border-yellow-600/50 focus:border-yellow-400 outline-none w-full resize-none"
+                                                      className="text-sm text-yellow-100/80 leading-relaxed bg-transparent border-b border-yellow-600/50 focus:border-[#d4af37] outline-none w-full resize-none"
                                                       rows={2}
                                                     />
                                                   ) : (
@@ -441,10 +441,10 @@ export function LuxuryMenuPreview({ menu, onUpdateMenu }: LuxuryMenuPreviewProps
                                                         )
                                                       }
                                                       onBlur={() => setEditingItemId(null)}
-                                                      className="text-xl font-serif font-bold text-yellow-400 bg-transparent border-b border-yellow-600/50 focus:border-yellow-400 outline-none w-16 text-right"
+                                                      className="text-xl font-serif font-bold text-[#d4af37] bg-transparent border-b border-yellow-600/50 focus:border-[#d4af37] outline-none w-16 text-right"
                                                     />
                                                   ) : (
-                                                    <div className="text-xl font-serif font-bold text-yellow-400">
+                                                    <div className="text-xl font-serif font-bold text-[#d4af37]">
                                                       {item.price?.toFixed(0)}
                                                     </div>
                                                   )}
@@ -459,7 +459,7 @@ export function LuxuryMenuPreview({ menu, onUpdateMenu }: LuxuryMenuPreviewProps
                                                       size="sm"
                                                       variant="ghost"
                                                       onClick={() => editItem(item.id)}
-                                                      className="h-6 w-6 p-0 text-yellow-400/70 hover:text-yellow-400 hover:bg-yellow-600/20 bg-yellow-600/10"
+                                                      className="h-6 w-6 p-0 text-[#d4af37]/70 hover:text-[#d4af37] hover:bg-yellow-600/20 bg-yellow-600/10"
                                                     >
                                                       <Edit className="w-3 h-3" />
                                                     </Button>
@@ -467,7 +467,7 @@ export function LuxuryMenuPreview({ menu, onUpdateMenu }: LuxuryMenuPreviewProps
                                                       size="sm"
                                                       variant="ghost"
                                                       onClick={() => deleteItem(category.id, item.id)}
-                                                      className="h-6 w-6 p-0 text-yellow-400/70 hover:text-red-400 hover:bg-red-500/20 bg-yellow-600/10"
+                                                      className="h-6 w-6 p-0 text-[#d4af37]/70 hover:text-red-400 hover:bg-red-500/20 bg-yellow-600/10"
                                                     >
                                                       <Trash2 className="w-3 h-3" />
                                                     </Button>
@@ -493,7 +493,7 @@ export function LuxuryMenuPreview({ menu, onUpdateMenu }: LuxuryMenuPreviewProps
                                           <Button
                                             variant="ghost"
                                             onClick={() => addItem(category.id)}
-                                            className="text-yellow-400/70 hover:text-yellow-400 hover:bg-yellow-600/20"
+                                            className="text-[#d4af37]/70 hover:text-[#d4af37] hover:bg-yellow-600/20"
                                           >
                                             <Plus className="w-4 h-4 mr-2" />
                                             Add first item
@@ -515,7 +515,7 @@ export function LuxuryMenuPreview({ menu, onUpdateMenu }: LuxuryMenuPreviewProps
                         <Button
                           onClick={addCategory}
                           variant="outline"
-                          className="border-yellow-600/50 text-yellow-400 hover:bg-yellow-600/10 bg-transparent"
+                          className="border-yellow-600/50 text-[#d4af37] hover:bg-yellow-600/10 bg-transparent"
                         >
                           <Plus className="w-4 h-4 mr-2" />
                           Add New Category
@@ -557,13 +557,13 @@ export function LuxuryMenuPreview({ menu, onUpdateMenu }: LuxuryMenuPreviewProps
                                     {...provided.dragHandleProps}
                                     className="cursor-grab p-1 hover:bg-yellow-600/20 rounded bg-yellow-600/10"
                                   >
-                                    <GripVertical className="w-4 h-4 text-yellow-400/70" />
+                                    <GripVertical className="w-4 h-4 text-[#d4af37]/70" />
                                   </div>
                                   <Button
                                     size="sm"
                                     variant="ghost"
                                     onClick={() => toggleSpecialCategory(category.id, category.isSpecial || false)}
-                                    className="h-6 w-6 p-0 text-yellow-400/70 hover:text-yellow-400 hover:bg-yellow-600/20 bg-yellow-600/10"
+                                    className="h-6 w-6 p-0 text-[#d4af37]/70 hover:text-[#d4af37] hover:bg-yellow-600/20 bg-yellow-600/10"
                                   >
                                     <Sparkles className="w-3 h-3" />
                                   </Button>
@@ -571,7 +571,7 @@ export function LuxuryMenuPreview({ menu, onUpdateMenu }: LuxuryMenuPreviewProps
                                     size="sm"
                                     variant="ghost"
                                     onClick={() => startEditingCategory(category.id, category.name)}
-                                    className="h-6 w-6 p-0 text-yellow-400/70 hover:text-yellow-400 hover:bg-yellow-600/20 bg-yellow-600/10"
+                                    className="h-6 w-6 p-0 text-[#d4af37]/70 hover:text-[#d4af37] hover:bg-yellow-600/20 bg-yellow-600/10"
                                   >
                                     <Edit className="w-3 h-3" />
                                   </Button>
@@ -579,7 +579,7 @@ export function LuxuryMenuPreview({ menu, onUpdateMenu }: LuxuryMenuPreviewProps
                                     size="sm"
                                     variant="ghost"
                                     onClick={() => deleteCategory(category.id)}
-                                    className="h-6 w-6 p-0 text-yellow-400/70 hover:text-red-400 hover:bg-red-500/20 bg-yellow-600/10"
+                                    className="h-6 w-6 p-0 text-[#d4af37]/70 hover:text-red-400 hover:bg-red-500/20 bg-yellow-600/10"
                                   >
                                     <Trash2 className="w-3 h-3" />
                                   </Button>
@@ -587,7 +587,7 @@ export function LuxuryMenuPreview({ menu, onUpdateMenu }: LuxuryMenuPreviewProps
                                     size="sm"
                                     variant="ghost"
                                     onClick={() => addItem(category.id)}
-                                    className="h-6 w-6 p-0 text-yellow-400/70 hover:text-yellow-400 hover:bg-yellow-600/20 bg-yellow-600/10"
+                                    className="h-6 w-6 p-0 text-[#d4af37]/70 hover:text-[#d4af37] hover:bg-yellow-600/20 bg-yellow-600/10"
                                   >
                                     <Plus className="w-4 h-4 mr-2" />
                                   </Button>
@@ -604,14 +604,14 @@ export function LuxuryMenuPreview({ menu, onUpdateMenu }: LuxuryMenuPreviewProps
                                         if (e.key === "Enter") saveCategory()
                                         if (e.key === "Escape") cancelEditingCategory()
                                       }}
-                                      className="text-2xl font-serif font-bold bg-yellow-600/20 border-yellow-600/50 text-yellow-400 tracking-wider"
+                                      className="text-2xl font-serif font-bold bg-yellow-600/20 border-yellow-600/50 text-[#d4af37] tracking-wider"
                                       autoFocus
                                     />
                                   </div>
                                 ) : (
                                   <div className="mb-4">
                                     <h3
-                                      className="text-2xl font-serif font-bold text-yellow-400 tracking-wider cursor-pointer hover:text-yellow-300 transition-colors"
+                                      className="text-2xl font-serif font-bold text-[#d4af37] tracking-wider cursor-pointer hover:text-yellow-300 transition-colors"
                                       onClick={() =>
                                         isPreviewMode && startEditingCategory(category.id, category.name)
                                       }
@@ -653,7 +653,7 @@ export function LuxuryMenuPreview({ menu, onUpdateMenu }: LuxuryMenuPreviewProps
                                                           : "opacity-0 translate-x-4 pointer-events-none"
                                                       }`}
                                                     >
-                                                      <GripVertical className="w-4 h-4 text-yellow-400/50" />
+                                                      <GripVertical className="w-4 h-4 text-[#d4af37]/50" />
                                                     </div>
                                                     {editingItemId === item.id ? (
                                                       <input
@@ -667,7 +667,7 @@ export function LuxuryMenuPreview({ menu, onUpdateMenu }: LuxuryMenuPreviewProps
                                                           )
                                                         }
                                                         onBlur={() => setEditingItemId(null)}
-                                                        className="text-lg font-serif font-semibold text-yellow-200 bg-transparent border-b border-yellow-600/50 focus:border-yellow-400 outline-none"
+                                                        className="text-lg font-serif font-semibold text-yellow-200 bg-transparent border-b border-yellow-600/50 focus:border-[#d4af37] outline-none"
                                                         autoFocus
                                                       />
                                                     ) : (
@@ -687,7 +687,7 @@ export function LuxuryMenuPreview({ menu, onUpdateMenu }: LuxuryMenuPreviewProps
                                                         )
                                                       }
                                                       onBlur={() => setEditingItemId(null)}
-                                                      className="text-sm text-yellow-100/80 leading-relaxed bg-transparent border-b border-yellow-600/50 focus:border-yellow-400 outline-none w-full resize-none"
+                                                      className="text-sm text-yellow-100/80 leading-relaxed bg-transparent border-b border-yellow-600/50 focus:border-[#d4af37] outline-none w-full resize-none"
                                                       rows={2}
                                                     />
                                                   ) : (
@@ -711,10 +711,10 @@ export function LuxuryMenuPreview({ menu, onUpdateMenu }: LuxuryMenuPreviewProps
                                                         )
                                                       }
                                                       onBlur={() => setEditingItemId(null)}
-                                                      className="text-xl font-serif font-bold text-yellow-400 bg-transparent border-b border-yellow-600/50 focus:border-yellow-400 outline-none w-16 text-right"
+                                                      className="text-xl font-serif font-bold text-[#d4af37] bg-transparent border-b border-yellow-600/50 focus:border-[#d4af37] outline-none w-16 text-right"
                                                     />
                                                   ) : (
-                                                    <div className="text-xl font-serif font-bold text-yellow-400">
+                                                    <div className="text-xl font-serif font-bold text-[#d4af37]">
                                                       {item.price?.toFixed(0)}
                                                     </div>
                                                   )}
@@ -729,7 +729,7 @@ export function LuxuryMenuPreview({ menu, onUpdateMenu }: LuxuryMenuPreviewProps
                                                       size="sm"
                                                       variant="ghost"
                                                       onClick={() => editItem(item.id)}
-                                                      className="h-6 w-6 p-0 text-yellow-400/70 hover:text-yellow-400 hover:bg-yellow-600/20 bg-yellow-600/10"
+                                                      className="h-6 w-6 p-0 text-[#d4af37]/70 hover:text-[#d4af37] hover:bg-yellow-600/20 bg-yellow-600/10"
                                                     >
                                                       <Edit className="w-3 h-3" />
                                                     </Button>
@@ -737,7 +737,7 @@ export function LuxuryMenuPreview({ menu, onUpdateMenu }: LuxuryMenuPreviewProps
                                                       size="sm"
                                                       variant="ghost"
                                                       onClick={() => deleteItem(category.id, item.id)}
-                                                      className="h-6 w-6 p-0 text-yellow-400/70 hover:text-red-400 hover:bg-red-500/20 bg-yellow-600/10"
+                                                      className="h-6 w-6 p-0 text-[#d4af37]/70 hover:text-red-400 hover:bg-red-500/20 bg-yellow-600/10"
                                                     >
                                                       <Trash2 className="w-3 h-3" />
                                                     </Button>
@@ -763,7 +763,7 @@ export function LuxuryMenuPreview({ menu, onUpdateMenu }: LuxuryMenuPreviewProps
                                           <Button
                                             variant="ghost"
                                             onClick={() => addItem(category.id)}
-                                            className="text-yellow-400/70 hover:text-yellow-400 hover:bg-yellow-600/20"
+                                            className="text-[#d4af37]/70 hover:text-[#d4af37] hover:bg-yellow-600/20"
                                           >
                                             <Plus className="w-4 h-4 mr-2" />
                                             Add first item
@@ -785,7 +785,7 @@ export function LuxuryMenuPreview({ menu, onUpdateMenu }: LuxuryMenuPreviewProps
                         <Button
                           onClick={addCategory}
                           variant="outline"
-                          className="border-yellow-600/50 text-yellow-400 hover:bg-yellow-600/10 bg-transparent"
+                          className="border-yellow-600/50 text-[#d4af37] hover:bg-yellow-600/10 bg-transparent"
                         >
                           <Plus className="w-4 h-4 mr-2" />
                           Add New Category

--- a/components/templates/sweet-treats-menu-preview.tsx
+++ b/components/templates/sweet-treats-menu-preview.tsx
@@ -97,7 +97,7 @@ const MenuItemComponent: React.FC<MenuItemComponentProps> = ({ item, categoryId,
 
   return (
     <motion.div
-      className="flex justify-between items-center py-2 group"
+      className="flex justify-between items-center py-2 group border-b border-pink-200"
       initial={{ opacity: 0, y: -10 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: -10 }}
@@ -106,7 +106,7 @@ const MenuItemComponent: React.FC<MenuItemComponentProps> = ({ item, categoryId,
         <EditableText
           value={item.name}
           onChange={(name) => onUpdate({ name })}
-          className="text-gray-700 font-medium"
+          className="text-pink-600 font-medium"
           placeholder="Item name"
         />
       </div>
@@ -117,7 +117,7 @@ const MenuItemComponent: React.FC<MenuItemComponentProps> = ({ item, categoryId,
             const price = Number.parseFloat(priceStr.replace("$", "")) || 0
             onUpdate({ price })
           }}
-          className="text-gray-700 font-medium"
+          className="text-pink-600 font-medium"
           placeholder="$0.00"
         />
         {!isPreviewMode && (
@@ -159,7 +159,7 @@ const MenuCategoryComponent: React.FC<MenuCategoryComponentProps> = ({ category,
         <EditableText
           value={category.name}
           onChange={(name) => onUpdate({ name })}
-          className="text-4xl font-bold text-coral-500 mb-4"
+          className="text-4xl font-bold text-pink-600 mb-4"
           placeholder="Category Name"
         />
       </div>
@@ -231,15 +231,12 @@ export function SweetTreatsMenuPreview() {
   const displayCategories = categories.length > 0 ? categories : []
 
   return (
-    <div className="min-h-screen bg-white">
+    <div className="min-h-screen bg-pink-50">
       {/* Header */}
       <div className="text-center py-16 text-white" style={{ backgroundColor: "#FF7F7F" }}>
         <h1
-          className="text-6xl font-bold mb-4"
-          style={{
-            fontFamily: "Dancing Script, cursive",
-            color: "#E6F3F0",
-          }}
+          className="text-6xl font-bold mb-4 text-pink-600"
+          style={{ fontFamily: "Dancing Script, cursive" }}
         >
           Sweet Treats
         </h1>

--- a/lib/pdf-server-components/templates/BorcelleCoffeePDFTemplate.tsx
+++ b/lib/pdf-server-components/templates/BorcelleCoffeePDFTemplate.tsx
@@ -52,20 +52,20 @@ export default function BorcelleCoffeePDFTemplate({
   const currency = restaurant.currency || '$'
   
   return (
-    <div style={{ 
-      backgroundColor: '#1a1a1a', 
-      minHeight: '100vh', 
+    <div style={{
+      background: 'linear-gradient(to bottom right, #fffbeb, #fff7ed)',
+      minHeight: '100vh',
       padding: '48px',
       fontFamily: 'Arial, sans-serif',
-      color: '#ffffff'
+      color: '#78350f'
     }}>
       <div style={{ maxWidth: '1024px', margin: '0 auto' }}>
         {/* Menu Header */}
         <div style={{ textAlign: 'center', marginBottom: '64px' }}>
-          <h1 style={{ 
-            fontSize: '48px', 
-            fontWeight: '700', 
-            color: '#ffffff',
+          <h1 style={{
+            fontSize: '48px',
+            fontWeight: '700',
+            color: '#78350f',
             marginBottom: '16px',
             textTransform: 'uppercase',
             letterSpacing: '0.2em',
@@ -76,13 +76,13 @@ export default function BorcelleCoffeePDFTemplate({
           <div style={{
             width: '80px',
             height: '2px',
-            backgroundColor: '#d4af37',
+            backgroundColor: '#d97706',
             margin: '0 auto 16px'
           }}></div>
-          <h2 style={{ 
-            fontSize: '20px', 
-            fontWeight: '400', 
-            color: '#d4af37',
+          <h2 style={{
+            fontSize: '20px',
+            fontWeight: '400',
+            color: '#d97706',
             margin: 0,
             letterSpacing: '0.1em',
             textTransform: 'uppercase'
@@ -97,14 +97,14 @@ export default function BorcelleCoffeePDFTemplate({
             <div key={category.id}>
               {/* Category Header */}
               <div style={{
-                borderBottom: '1px solid #d4af37',
+                borderBottom: '1px solid #d97706',
                 marginBottom: '24px',
                 paddingBottom: '16px'
               }}>
-                <h3 style={{ 
-                  fontSize: '28px', 
-                  fontWeight: '600', 
-                  color: '#d4af37',
+                <h3 style={{
+                  fontSize: '28px',
+                  fontWeight: '600',
+                  color: '#78350f',
                   margin: 0,
                   textTransform: 'uppercase',
                   letterSpacing: '0.1em'
@@ -117,10 +117,10 @@ export default function BorcelleCoffeePDFTemplate({
               <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '24px' }}>
                 {category.menu_items.map((item) => (
                   <div key={item.id} style={{
-                    backgroundColor: '#2a2a2a',
+                    backgroundColor: '#fff7ed',
                     borderRadius: '12px',
                     padding: '20px',
-                    border: '1px solid #333333'
+                    border: '1px solid #fed7aa'
                   }}>
                     <div style={{
                       display: 'flex',
@@ -128,28 +128,28 @@ export default function BorcelleCoffeePDFTemplate({
                       alignItems: 'flex-start',
                       marginBottom: '12px'
                     }}>
-                      <h4 style={{ 
-                        fontSize: '18px', 
-                        fontWeight: '600', 
-                        color: '#ffffff',
+                      <h4 style={{
+                        fontSize: '18px',
+                        fontWeight: '600',
+                        color: '#78350f',
                         margin: 0,
                         flex: 1
                       }}>
                         {item.name}
                       </h4>
-                      <div style={{ 
-                        fontSize: '20px', 
-                        fontWeight: '700', 
-                        color: '#d4af37',
+                      <div style={{
+                        fontSize: '20px',
+                        fontWeight: '700',
+                        color: '#b45309',
                         marginLeft: '16px'
                       }}>
                         {currency}{item.price?.toFixed(2) || '0.00'}
                       </div>
                     </div>
                     {item.description && (
-                      <p style={{ 
-                        fontSize: '14px', 
-                        color: '#cccccc', 
+                      <p style={{
+                        fontSize: '14px',
+                        color: '#92400e',
                         lineHeight: 1.5,
                         margin: 0
                       }}>
@@ -164,22 +164,22 @@ export default function BorcelleCoffeePDFTemplate({
         </div>
 
         {/* Footer */}
-        <div style={{ 
-          marginTop: '64px', 
+        <div style={{
+          marginTop: '64px',
           textAlign: 'center',
           padding: '32px',
-          borderTop: '1px solid #d4af37'
+          borderTop: '1px solid #d97706'
         }}>
-          <p style={{ 
-            color: '#d4af37', 
+          <p style={{
+            color: '#d97706',
             fontWeight: '500',
             fontSize: '16px',
             margin: '0 0 8px 0'
           }}>
             Crafted with passion, served with excellence
           </p>
-          <p style={{ 
-            color: '#cccccc', 
+          <p style={{
+            color: '#78350f',
             fontWeight: '400',
             fontSize: '14px',
             margin: 0

--- a/lib/pdf-server-components/templates/BotanicalCafePDFTemplate.tsx
+++ b/lib/pdf-server-components/templates/BotanicalCafePDFTemplate.tsx
@@ -42,9 +42,34 @@ interface BotanicalCafePDFTemplateProps {
   pdfMode?: boolean
 }
 
-export default function BotanicalCafePDFTemplate({ 
-  restaurant, 
-  categories, 
+// Botanical illustrations used in preview for decorative accents
+const FeatherIllustration = () => (
+  <svg width="120" height="300" viewBox="0 0 120 300" style={{ position: 'absolute', color: '#16a34a33' }}>
+    <g fill="currentColor">
+      <path d="M60 10 Q50 50 45 100 Q40 150 35 200 Q30 250 25 290 L35 290 Q40 250 45 200 Q50 150 55 100 Q60 50 70 10 Z" />
+      <path d="M60 20 Q70 30 80 40 Q75 45 65 35 Q60 30 60 20" />
+      <path d="M60 40 Q75 50 85 60 Q80 65 70 55 Q60 50 60 40" />
+      <path d="M60 60 Q80 70 90 80 Q85 85 75 75 Q60 70 60 60" />
+      <path d="M60 80 Q85 90 95 100 Q90 105 80 95 Q60 90 60 80" />
+    </g>
+  </svg>
+)
+
+const LeafIllustration = () => (
+  <svg width="100" height="150" viewBox="0 0 100 150" style={{ position: 'absolute', color: '#16a34a4d' }}>
+    <g fill="currentColor">
+      <path d="M50 10 Q30 30 20 60 Q15 90 25 120 Q35 140 50 145 Q65 140 75 120 Q85 90 80 60 Q70 30 50 10 Z" />
+      <path d="M50 20 L50 130" stroke="currentColor" strokeWidth="1" fill="none" />
+      <path d="M50 40 Q40 45 35 55" stroke="currentColor" strokeWidth="0.5" fill="none" />
+      <path d="M50 60 Q60 65 65 75" stroke="currentColor" strokeWidth="0.5" fill="none" />
+      <path d="M50 80 Q40 85 35 95" stroke="currentColor" strokeWidth="0.5" fill="none" />
+    </g>
+  </svg>
+)
+
+export default function BotanicalCafePDFTemplate({
+  restaurant,
+  categories,
   language = 'ar',
   customizations,
   pdfMode = false
@@ -52,17 +77,24 @@ export default function BotanicalCafePDFTemplate({
   const currency = restaurant.currency || '$'
   
   return (
-    <div style={{ 
-      backgroundColor: '#f0f9ff', 
-      minHeight: '100vh', 
+    <div style={{
+      background: 'linear-gradient(to bottom right, #f0fdf4, #ecfdf5)',
+      minHeight: '100vh',
       padding: '48px',
       fontFamily: 'Georgia, serif',
-      backgroundImage: `
-        radial-gradient(circle at 25% 25%, rgba(34, 197, 94, 0.1) 0%, transparent 50%),
-        radial-gradient(circle at 75% 75%, rgba(16, 185, 129, 0.1) 0%, transparent 50%)
-      `
+      position: 'relative'
     }}>
-      <div style={{ maxWidth: '1024px', margin: '0 auto' }}>
+      {/* Background Illustrations */}
+      <div style={{ top: '80px', left: '40px' }}>
+        <FeatherIllustration />
+      </div>
+      <div style={{ bottom: '80px', right: '40px' }}>
+        <LeafIllustration />
+      </div>
+      <div style={{ top: '50%', left: '25%', transform: 'translateY(-50%)' }}>
+        <LeafIllustration />
+      </div>
+      <div style={{ maxWidth: '1024px', margin: '0 auto', position: 'relative', zIndex: 10 }}>
         {/* Menu Header */}
         <div style={{ textAlign: 'center', marginBottom: '64px' }}>
           <div style={{

--- a/lib/pdf-server-components/templates/ChalkboardCoffeePDFTemplate.tsx
+++ b/lib/pdf-server-components/templates/ChalkboardCoffeePDFTemplate.tsx
@@ -42,9 +42,51 @@ interface ChalkboardCoffeePDFTemplateProps {
   pdfMode?: boolean
 }
 
-export default function ChalkboardCoffeePDFTemplate({ 
-  restaurant, 
-  categories, 
+// Chalk-style SVG components mirrored from the preview
+const ChalkCoffeeBean = ({ style = {} }) => (
+  <svg width="40" height="30" viewBox="0 0 40 30" style={{ position: 'absolute', ...style }}>
+    <g fill="none" stroke="white" strokeWidth="2" strokeLinecap="round">
+      <ellipse cx="20" cy="15" rx="15" ry="12" />
+      <ellipse cx="20" cy="15" rx="10" ry="8" />
+      <path d="M15 10c2-1 4-1 6 0" />
+    </g>
+  </svg>
+)
+
+const ChalkCoffeeCup = ({ style = {} }) => (
+  <svg width="60" height="50" viewBox="0 0 60 50" style={{ position: 'absolute', ...style }}>
+    <g fill="none" stroke="white" strokeWidth="2" strokeLinecap="round">
+      <ellipse cx="25" cy="40" rx="20" ry="6" />
+      <path d="M5 40 Q10 20 15 15 Q20 10 25 10 Q30 10 35 15 Q40 20 45 40" />
+      <ellipse cx="25" cy="15" rx="15" ry="4" />
+      <path d="M45 25 Q55 25 55 35 Q55 40 45 40" />
+      <path d="M15 20 Q20 25 25 30 Q30 25 35 20" strokeWidth="1" />
+    </g>
+  </svg>
+)
+
+const ChalkArrow = ({ style = {} }) => (
+  <svg width="80" height="20" viewBox="0 0 80 20" style={{ position: 'absolute', ...style }}>
+    <g fill="none" stroke="white" strokeWidth="2" strokeLinecap="round">
+      <path d="M5 10 Q20 8 40 10 Q60 12 70 10" />
+      <path d="M65 6 L70 10 L65 14" />
+    </g>
+  </svg>
+)
+
+const ChalkLeaf = ({ style = {} }) => (
+  <svg width="50" height="80" viewBox="0 0 50 80" style={{ position: 'absolute', ...style }}>
+    <g fill="none" stroke="white" strokeWidth="2" strokeLinecap="round">
+      <path d="M25 5 Q35 20 40 40 Q35 60 25 75 Q15 60 10 40 Q15 20 25 5" />
+      <path d="M25 15 Q30 25 35 35 Q30 45 25 55 Q20 45 15 35 Q20 25 25 15" />
+      <path d="M25 5 L25 75" strokeWidth="1" />
+    </g>
+  </svg>
+)
+
+export default function ChalkboardCoffeePDFTemplate({
+  restaurant,
+  categories,
   language = 'ar',
   customizations,
   pdfMode = false
@@ -52,18 +94,39 @@ export default function ChalkboardCoffeePDFTemplate({
   const currency = restaurant.currency || '$'
   
   return (
-    <div style={{ 
-      backgroundColor: '#2d3748', 
-      minHeight: '100vh', 
+    <div style={{
+      background: `
+        radial-gradient(circle at 20% 30%, rgba(64,64,64,0.3) 0%, transparent 50%),
+        radial-gradient(circle at 80% 70%, rgba(96,96,96,0.2) 0%, transparent 50%),
+        radial-gradient(circle at 40% 80%, rgba(48,48,48,0.4) 0%, transparent 50%),
+        linear-gradient(135deg, #2d2d2d 0%, #1a1a1a 50%, #0f0f0f 100%)
+      `,
+      minHeight: '100vh',
       padding: '48px',
-      fontFamily: 'Courier New, monospace',
+      fontFamily: 'cursive',
       color: '#ffffff',
-      backgroundImage: `
-        radial-gradient(circle at 20% 80%, rgba(255, 255, 255, 0.1) 0%, transparent 50%),
-        radial-gradient(circle at 80% 20%, rgba(255, 255, 255, 0.05) 0%, transparent 50%)
-      `
+      position: 'relative'
     }}>
-      <div style={{ maxWidth: '1024px', margin: '0 auto' }}>
+      {/* Chalk texture overlay */}
+      <div style={{
+        position: 'absolute',
+        inset: 0,
+        opacity: 0.2,
+        backgroundImage: `
+          radial-gradient(circle at 25% 25%, white 1px, transparent 1px),
+          radial-gradient(circle at 75% 75%, white 0.5px, transparent 0.5px),
+          radial-gradient(circle at 50% 50%, white 0.8px, transparent 0.8px)
+        `,
+        backgroundSize: '100px 100px, 150px 150px, 80px 80px'
+      }}></div>
+
+      {/* Decorative chalk elements */}
+      <ChalkCoffeeBean style={{ left: '-40px', top: '160px', opacity: 0.4, transform: 'rotate(12deg)' }} />
+      <ChalkCoffeeCup style={{ right: '-60px', top: '200px', opacity: 0.3, transform: 'rotate(-12deg)' }} />
+      <ChalkLeaf style={{ left: '-30px', bottom: '200px', opacity: 0.35, transform: 'rotate(45deg)' }} />
+      <ChalkCoffeeBean style={{ right: '-40px', bottom: '240px', opacity: 0.4, transform: 'rotate(-30deg)' }} />
+
+      <div style={{ maxWidth: '1024px', margin: '0 auto', position: 'relative', zIndex: 10 }}>
         {/* Menu Header */}
         <div style={{ textAlign: 'center', marginBottom: '64px' }}>
           <div style={{

--- a/lib/pdf-server-components/templates/FastFoodPDFTemplate.tsx
+++ b/lib/pdf-server-components/templates/FastFoodPDFTemplate.tsx
@@ -52,9 +52,9 @@ export default function FastFoodPDFTemplate({
   const currency = restaurant.currency || '$'
   
   return (
-    <div style={{ 
-      backgroundColor: '#ff6b35', 
-      minHeight: '100vh', 
+    <div style={{
+      backgroundColor: '#F5E6D3',
+      minHeight: '100vh',
       padding: '32px',
       fontFamily: 'Arial, sans-serif'
     }}>
@@ -67,10 +67,10 @@ export default function FastFoodPDFTemplate({
             padding: '32px',
             boxShadow: '0 20px 25px -5px rgba(0, 0, 0, 0.1)'
           }}>
-            <h1 style={{ 
-              fontSize: '48px', 
-              fontWeight: '900', 
-              color: '#ff6b35',
+            <h1 style={{
+              fontSize: '48px',
+              fontWeight: '900',
+              color: '#C41E3A',
               marginBottom: '16px',
               textTransform: 'uppercase',
               letterSpacing: '0.1em',
@@ -81,7 +81,7 @@ export default function FastFoodPDFTemplate({
             <div style={{
               width: '80px',
               height: '4px',
-              backgroundColor: '#ff6b35',
+              backgroundColor: '#C41E3A',
               margin: '0 auto 16px'
             }}></div>
             <h2 style={{ 
@@ -106,14 +106,14 @@ export default function FastFoodPDFTemplate({
             }}>
               {/* Category Header */}
               <div style={{
-                borderBottom: '3px solid #ff6b35',
+                borderBottom: '3px solid #C41E3A',
                 marginBottom: '24px',
                 paddingBottom: '16px'
               }}>
-                <h3 style={{ 
-                  fontSize: '32px', 
-                  fontWeight: '900', 
-                  color: '#ff6b35',
+                <h3 style={{
+                  fontSize: '32px',
+                  fontWeight: '900',
+                  color: '#C41E3A',
                   margin: 0,
                   textTransform: 'uppercase',
                   letterSpacing: '0.1em'
@@ -126,10 +126,10 @@ export default function FastFoodPDFTemplate({
               <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '24px' }}>
                 {category.menu_items.map((item) => (
                   <div key={item.id} style={{
-                    backgroundColor: '#f8fafc',
+                    backgroundColor: '#F5E6D3',
                     borderRadius: '12px',
                     padding: '20px',
-                    border: '2px solid #e2e8f0',
+                    border: '2px solid #C41E3A',
                     position: 'relative',
                     overflow: 'hidden'
                   }}>
@@ -139,7 +139,7 @@ export default function FastFoodPDFTemplate({
                       left: 0,
                       width: '4px',
                       height: '100%',
-                      backgroundColor: '#ff6b35'
+                      backgroundColor: '#C41E3A'
                     }}></div>
                     <div style={{
                       display: 'flex',
@@ -147,29 +147,29 @@ export default function FastFoodPDFTemplate({
                       alignItems: 'flex-start',
                       marginBottom: '12px'
                     }}>
-                      <h4 style={{ 
-                        fontSize: '18px', 
-                        fontWeight: '700', 
-                        color: '#1f2937',
+                      <h4 style={{
+                        fontSize: '18px',
+                        fontWeight: '700',
+                        color: '#C41E3A',
                         margin: 0,
                         flex: 1,
                         textTransform: 'uppercase'
                       }}>
                         {item.name}
                       </h4>
-                      <div style={{ 
-                        fontSize: '24px', 
-                        fontWeight: '900', 
-                        color: '#ff6b35',
+                      <div style={{
+                        fontSize: '24px',
+                        fontWeight: '900',
+                        color: '#C41E3A',
                         marginLeft: '16px'
                       }}>
                         {currency}{item.price?.toFixed(2) || '0.00'}
                       </div>
                     </div>
                     {item.description && (
-                      <p style={{ 
-                        fontSize: '14px', 
-                        color: '#6b7280', 
+                      <p style={{
+                        fontSize: '14px',
+                        color: '#7c2d12',
                         lineHeight: 1.5,
                         margin: 0
                       }}>
@@ -192,10 +192,11 @@ export default function FastFoodPDFTemplate({
             backgroundColor: '#ffffff',
             borderRadius: '16px',
             padding: '24px',
-            boxShadow: '0 10px 15px -3px rgba(0, 0, 0, 0.1)'
+            boxShadow: '0 10px 15px -3px rgba(0, 0, 0, 0.1)',
+            border: '2px solid #C41E3A'
           }}>
-            <p style={{ 
-              color: '#ff6b35', 
+            <p style={{
+              color: '#C41E3A',
               fontWeight: '700',
               fontSize: '18px',
               margin: '0 0 8px 0',
@@ -203,8 +204,8 @@ export default function FastFoodPDFTemplate({
             }}>
               Fast • Fresh • Delicious
             </p>
-            <p style={{ 
-              color: '#374151', 
+            <p style={{
+              color: '#7c2d12',
               fontWeight: '500',
               fontSize: '14px',
               margin: 0

--- a/lib/pdf-server-components/templates/SimpleCoffeePDFTemplate.tsx
+++ b/lib/pdf-server-components/templates/SimpleCoffeePDFTemplate.tsx
@@ -52,38 +52,38 @@ export default function SimpleCoffeePDFTemplate({
   const currency = restaurant.currency || '$'
   
   return (
-    <div style={{ 
-      backgroundColor: '#f5f5f5', 
-      minHeight: '100vh', 
+    <div style={{
+      background: 'linear-gradient(to bottom right, #fffbeb, #ffedd5)',
+      minHeight: '100vh',
       padding: '48px',
       fontFamily: 'Arial, sans-serif'
     }}>
       <div style={{ maxWidth: '800px', margin: '0 auto' }}>
         {/* Menu Header */}
         <div style={{ textAlign: 'center', marginBottom: '48px' }}>
-          <h1 style={{ 
-            fontSize: '36px', 
-            fontWeight: '700', 
-            color: '#2d3748',
-            marginBottom: '16px',
-            margin: 0
-          }}>
-            {restaurant.name || 'COFFEE SHOP'}
-          </h1>
           <div style={{
-            width: '60px',
-            height: '2px',
-            backgroundColor: '#8b4513',
-            margin: '0 auto 16px'
-          }}></div>
-          <h2 style={{ 
-            fontSize: '18px', 
-            fontWeight: '400', 
-            color: '#718096',
-            margin: 0
+            background: 'linear-gradient(to right, #d97706, #ea580c)',
+            padding: '32px',
+            borderRadius: '12px'
           }}>
-            Menu
-          </h2>
+            <h1 style={{
+              fontSize: '36px',
+              fontWeight: '700',
+              color: '#ffffff',
+              marginBottom: '8px',
+              margin: 0
+            }}>
+              {restaurant.name || 'COFFEE SHOP'}
+            </h1>
+            <h2 style={{
+              fontSize: '18px',
+              fontWeight: '400',
+              color: '#fef3c7',
+              margin: 0
+            }}>
+              Fresh Coffee & Delicious Treats
+            </h2>
+          </div>
         </div>
 
         {/* Menu Content */}
@@ -92,14 +92,14 @@ export default function SimpleCoffeePDFTemplate({
             <div key={category.id}>
               {/* Category Header */}
               <div style={{
-                borderBottom: '1px solid #e2e8f0',
+                borderBottom: '2px solid #fcd34d',
                 marginBottom: '20px',
                 paddingBottom: '12px'
               }}>
-                <h3 style={{ 
-                  fontSize: '24px', 
-                  fontWeight: '600', 
-                  color: '#2d3748',
+                <h3 style={{
+                  fontSize: '24px',
+                  fontWeight: '600',
+                  color: '#78350f',
                   margin: 0
                 }}>
                   {category.name}
@@ -114,23 +114,23 @@ export default function SimpleCoffeePDFTemplate({
                     justifyContent: 'space-between',
                     alignItems: 'flex-start',
                     padding: '16px',
-                    backgroundColor: '#ffffff',
+                    backgroundColor: '#fef3c7',
                     borderRadius: '8px',
-                    border: '1px solid #e2e8f0'
+                    border: '1px solid #fcd34d'
                   }}>
                     <div style={{ flex: 1 }}>
-                      <h4 style={{ 
-                        fontSize: '16px', 
-                        fontWeight: '600', 
-                        color: '#2d3748',
+                      <h4 style={{
+                        fontSize: '16px',
+                        fontWeight: '600',
+                        color: '#78350f',
                         margin: '0 0 4px 0'
                       }}>
                         {item.name}
                       </h4>
                       {item.description && (
-                        <p style={{ 
-                          fontSize: '14px', 
-                          color: '#718096', 
+                        <p style={{
+                          fontSize: '14px',
+                          color: '#92400e',
                           lineHeight: 1.4,
                           margin: 0
                         }}>
@@ -138,10 +138,10 @@ export default function SimpleCoffeePDFTemplate({
                         </p>
                       )}
                     </div>
-                    <div style={{ 
-                      fontSize: '16px', 
-                      fontWeight: '600', 
-                      color: '#8b4513',
+                    <div style={{
+                      fontSize: '16px',
+                      fontWeight: '600',
+                      color: '#b45309',
                       marginLeft: '16px'
                     }}>
                       {currency}{item.price?.toFixed(2) || '0.00'}
@@ -154,21 +154,20 @@ export default function SimpleCoffeePDFTemplate({
         </div>
 
         {/* Footer */}
-        <div style={{ 
-          marginTop: '48px', 
+        <div style={{
+          marginTop: '48px',
           textAlign: 'center',
           padding: '24px',
-          backgroundColor: '#ffffff',
-          borderRadius: '8px',
-          border: '1px solid #e2e8f0'
+          backgroundColor: '#92400e',
+          borderRadius: '8px'
         }}>
-          <p style={{ 
-            color: '#718096', 
+          <p style={{
+            color: '#ffffff',
             fontWeight: '500',
             fontSize: '14px',
             margin: 0
           }}>
-            Fresh coffee, every day
+            Thank you for choosing {restaurant.name}
           </p>
         </div>
       </div>

--- a/lib/pdf-server-components/templates/VintageBakeryPDFTemplate.tsx
+++ b/lib/pdf-server-components/templates/VintageBakeryPDFTemplate.tsx
@@ -52,9 +52,9 @@ export default function VintageBakeryPDFTemplate({
   const currency = restaurant.currency || '$'
   
   return (
-    <div style={{ 
-      backgroundColor: '#fef7ed', 
-      minHeight: '100vh', 
+    <div style={{
+      background: `linear-gradient(to bottom right, #fffbeb, #fef9c3)`,
+      minHeight: '100vh',
       padding: '48px',
       fontFamily: 'Georgia, serif',
       backgroundImage: `
@@ -73,9 +73,9 @@ export default function VintageBakeryPDFTemplate({
             borderRadius: '8px',
             boxShadow: '0 10px 15px -3px rgba(0, 0, 0, 0.1)'
           }}>
-            <h1 style={{ 
-              fontSize: '48px', 
-              fontWeight: '700', 
+            <h1 style={{
+              fontSize: '48px',
+              fontWeight: '700',
               color: '#92400e',
               marginBottom: '16px',
               textTransform: 'uppercase',
@@ -90,14 +90,14 @@ export default function VintageBakeryPDFTemplate({
               backgroundColor: '#d97706',
               margin: '0 auto 16px'
             }}></div>
-            <h2 style={{ 
-              fontSize: '20px', 
-              fontWeight: '400', 
+            <h2 style={{
+              fontSize: '20px',
+              fontWeight: '400',
               color: '#a16207',
               margin: 0,
               fontStyle: 'italic'
             }}>
-              Est. 1950
+              🥖 Artisan Bakery & Sweet Delights 🥖
             </h2>
           </div>
         </div>
@@ -119,16 +119,16 @@ export default function VintageBakeryPDFTemplate({
                 paddingBottom: '16px',
                 position: 'relative'
               }}>
-                <h3 style={{ 
-                  fontSize: '28px', 
-                  fontWeight: '700', 
+                <h3 style={{
+                  fontSize: '28px',
+                  fontWeight: '700',
                   color: '#92400e',
                   margin: 0,
                   textTransform: 'uppercase',
                   letterSpacing: '0.1em',
                   fontFamily: 'Georgia, serif'
                 }}>
-                  {category.name}
+                  🍞 {category.name}
                 </h3>
                 <div style={{
                   position: 'absolute',
@@ -153,14 +153,14 @@ export default function VintageBakeryPDFTemplate({
                     backgroundColor: '#fef7ed'
                   }}>
                     <div style={{ flex: 1 }}>
-                      <h4 style={{ 
-                        fontSize: '18px', 
-                        fontWeight: '600', 
+                      <h4 style={{
+                        fontSize: '18px',
+                        fontWeight: '600',
                         color: '#92400e',
                         margin: '0 0 8px 0',
                         fontFamily: 'Georgia, serif'
                       }}>
-                        {item.name}
+                        🥐 {item.name}
                       </h4>
                       {item.description && (
                         <p style={{ 
@@ -191,23 +191,23 @@ export default function VintageBakeryPDFTemplate({
         </div>
 
         {/* Footer */}
-        <div style={{ 
-          marginTop: '64px', 
+        <div style={{
+          marginTop: '64px',
           textAlign: 'center',
           padding: '32px',
           borderTop: '2px solid #fbbf24'
         }}>
-          <p style={{ 
-            color: '#92400e', 
+          <p style={{
+            color: '#92400e',
             fontWeight: '500',
             fontSize: '18px',
             margin: '0 0 8px 0',
             fontStyle: 'italic'
           }}>
-            "Baked with love since 1950"
+            🥖 Baked with love since 1950 🥖
           </p>
-          <p style={{ 
-            color: '#a16207', 
+          <p style={{
+            color: '#a16207',
             fontWeight: '600',
             fontSize: '16px',
             margin: 0

--- a/lib/pdf-server-components/templates/VintageCoffeePDFTemplate.tsx
+++ b/lib/pdf-server-components/templates/VintageCoffeePDFTemplate.tsx
@@ -52,31 +52,31 @@ export default function VintageCoffeePDFTemplate({
   const currency = restaurant.currency || '$'
   
   return (
-    <div style={{ 
-      backgroundColor: '#f5f5dc', 
-      minHeight: '100vh', 
+    <div style={{
+      background: 'linear-gradient(to bottom right, #f5f5dc, #fef3c7)',
+      minHeight: '100vh',
       padding: '48px',
       fontFamily: 'Times New Roman, serif',
       backgroundImage: `
-        radial-gradient(circle at 30% 70%, rgba(139, 69, 19, 0.1) 0%, transparent 50%),
-        radial-gradient(circle at 70% 30%, rgba(160, 82, 45, 0.1) 0%, transparent 50%)
+        radial-gradient(circle at 30% 70%, rgba(139,69,19,0.1) 0%, transparent 50%),
+        radial-gradient(circle at 70% 30%, rgba(160,82,45,0.1) 0%, transparent 50%)
       `
     }}>
       <div style={{ maxWidth: '1024px', margin: '0 auto' }}>
         {/* Menu Header */}
         <div style={{ textAlign: 'center', marginBottom: '64px' }}>
           <div style={{
-            border: '3px double #8b4513',
+            border: '3px double #7b4a2f',
             padding: '40px',
             marginBottom: '32px',
             backgroundColor: '#faf0e6',
             borderRadius: '8px',
             boxShadow: '0 10px 15px -3px rgba(0, 0, 0, 0.1)'
           }}>
-            <h1 style={{ 
-              fontSize: '48px', 
-              fontWeight: '700', 
-              color: '#8b4513',
+            <h1 style={{
+              fontSize: '48px',
+              fontWeight: '700',
+              color: '#7b4a2f',
               marginBottom: '16px',
               textTransform: 'uppercase',
               letterSpacing: '0.2em',
@@ -87,13 +87,13 @@ export default function VintageCoffeePDFTemplate({
             <div style={{
               width: '100px',
               height: '2px',
-              backgroundColor: '#a0522d',
+              backgroundColor: '#b45309',
               margin: '0 auto 16px'
             }}></div>
-            <h2 style={{ 
-              fontSize: '20px', 
-              fontWeight: '400', 
-              color: '#a0522d',
+            <h2 style={{
+              fontSize: '20px',
+              fontWeight: '400',
+              color: '#b45309',
               margin: 0,
               fontStyle: 'italic'
             }}>
@@ -106,23 +106,23 @@ export default function VintageCoffeePDFTemplate({
         <div style={{ display: 'flex', flexDirection: 'column', gap: '48px' }}>
           {categories.map((category) => (
             <div key={category.id} style={{
-              backgroundColor: '#faf0e6',
+              backgroundColor: '#fffaf0',
               borderRadius: '12px',
               padding: '32px',
               boxShadow: '0 10px 15px -3px rgba(0, 0, 0, 0.1)',
-              border: '2px solid #d2691e'
+              border: '2px solid #b45309'
             }}>
               {/* Category Header */}
               <div style={{
-                borderBottom: '2px solid #d2691e',
+                borderBottom: '2px solid #b45309',
                 marginBottom: '24px',
                 paddingBottom: '16px',
                 position: 'relative'
               }}>
-                <h3 style={{ 
-                  fontSize: '28px', 
-                  fontWeight: '700', 
-                  color: '#8b4513',
+                <h3 style={{
+                  fontSize: '28px',
+                  fontWeight: '700',
+                  color: '#7b4a2f',
                   margin: 0,
                   textTransform: 'uppercase',
                   letterSpacing: '0.1em',
@@ -136,7 +136,7 @@ export default function VintageCoffeePDFTemplate({
                   left: 0,
                   width: '60px',
                   height: '2px',
-                  backgroundColor: '#a0522d'
+                  backgroundColor: '#b45309'
                 }}></div>
               </div>
 
@@ -148,24 +148,24 @@ export default function VintageCoffeePDFTemplate({
                     justifyContent: 'space-between',
                     alignItems: 'flex-start',
                     padding: '20px',
-                    border: '1px solid #cd853f',
+                    border: '1px solid #d1b092',
                     borderRadius: '8px',
-                    backgroundColor: '#f5f5dc'
+                    backgroundColor: '#fffaf0'
                   }}>
                     <div style={{ flex: 1 }}>
-                      <h4 style={{ 
-                        fontSize: '18px', 
-                        fontWeight: '600', 
-                        color: '#8b4513',
+                      <h4 style={{
+                        fontSize: '18px',
+                        fontWeight: '600',
+                        color: '#7b4a2f',
                         margin: '0 0 8px 0',
                         fontFamily: 'Times New Roman, serif'
                       }}>
                         {item.name}
                       </h4>
                       {item.description && (
-                        <p style={{ 
-                          fontSize: '14px', 
-                          color: '#a0522d', 
+                        <p style={{
+                          fontSize: '14px',
+                          color: '#b45309',
                           lineHeight: 1.5,
                           margin: 0,
                           fontStyle: 'italic'
@@ -174,10 +174,10 @@ export default function VintageCoffeePDFTemplate({
                         </p>
                       )}
                     </div>
-                    <div style={{ 
-                      fontSize: '20px', 
-                      fontWeight: '700', 
-                      color: '#d2691e',
+                    <div style={{
+                      fontSize: '20px',
+                      fontWeight: '700',
+                      color: '#b45309',
                       marginLeft: '24px',
                       fontFamily: 'Times New Roman, serif'
                     }}>
@@ -191,23 +191,22 @@ export default function VintageCoffeePDFTemplate({
         </div>
 
         {/* Footer */}
-        <div style={{ 
-          marginTop: '64px', 
+        <div style={{
+          marginTop: '64px',
           textAlign: 'center',
           padding: '32px',
-          borderTop: '2px solid #d2691e'
+          backgroundColor: '#7b4a2f',
+          color: '#ffffff'
         }}>
-          <p style={{ 
-            color: '#8b4513', 
+          <p style={{
             fontWeight: '500',
             fontSize: '18px',
             margin: '0 0 8px 0',
             fontStyle: 'italic'
           }}>
-            "Brewed with tradition since 1960"
+            Brewed with tradition since 1960
           </p>
-          <p style={{ 
-            color: '#a0522d', 
+          <p style={{
             fontWeight: '600',
             fontSize: '16px',
             margin: 0


### PR DESCRIPTION
## Summary
- bring Botanical Cafe, Borcelle Coffee, Fast Food, Simple Coffee, Vintage Bakery, and Vintage Coffee PDF templates in line with preview color palettes and add decorative elements
- add chalk textures and doodles to Chalkboard Coffee PDF
- unify gold color for luxury preview and expand pink styling for Sweet Treats preview

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive prompt, requires manual config)*

------
https://chatgpt.com/codex/tasks/task_e_688e7d379cd08321abfdf421e132b968